### PR TITLE
Pass compile constants to weavers.

### DIFF
--- a/Fody.targets
+++ b/Fody.targets
@@ -57,6 +57,7 @@
           References="@(ReferencePath)"
           SignAssembly="$(FodySignAssembly)"
           ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
+          DefineConstants="$(DefineConstants)"
       />
   </Target>
 
@@ -74,6 +75,7 @@
           References="@(ReferencePath)"
           SignAssembly="$(FodySignAssembly)"
           ReferenceCopyLocalPaths="$(ReferenceCopyLocalPaths)"
+          DefineConstants="$(DefineConstants)"
       />
   </Target>
 

--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -18,7 +18,8 @@ public partial class Processor
     public string SolutionDirectoryPath;
     public IBuildEngine BuildEngine;
     public List<string> ReferenceCopyLocalPaths;
-    public bool DebugLoggingEnabled ;
+    public bool DebugLoggingEnabled;
+    public string DefineConstants;
 
     AddinFinder addinFinder;
     static Dictionary<string, AppDomain> solutionDomains = new Dictionary<string, AppDomain>(StringComparer.OrdinalIgnoreCase);
@@ -156,6 +157,7 @@ public partial class Processor
         innerWeaver.SolutionDirectoryPath = SolutionDirectoryPath;
         innerWeaver.Weavers = Weavers;
         innerWeaver.IntermediateDirectoryPath = IntermediateDirectoryPath;
+        innerWeaver.DefineConstants = DefineConstants;
         innerWeaver.Execute();
     }
 

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -30,6 +30,8 @@ namespace Fody
         [Required]
         public string SolutionDir { get; set; }
 
+        public string DefineConstants { get; set; }
+
         public override bool Execute()
         {
             List<string> referenceCopyLocalPaths = null;
@@ -49,7 +51,8 @@ namespace Fody
                            SolutionDirectoryPath = SolutionDir,
                            BuildEngine = BuildEngine,
                            ReferenceCopyLocalPaths = referenceCopyLocalPaths,
-                           DebugLoggingEnabled = DebugLoggingEnabled
+                           DebugLoggingEnabled = DebugLoggingEnabled,
+                           DefineConstants = DefineConstants
                        }.Execute();
         }
     }

--- a/FodyCommon/IInnerWeaver.cs
+++ b/FodyCommon/IInnerWeaver.cs
@@ -12,6 +12,7 @@ public interface IInnerWeaver
     string SolutionDirectoryPath { get; set; }
     bool DebugLoggingEnabled { get; set; }
     List<string> ReferenceCopyLocalPaths { get; set; }
+    string DefineConstants { get; set; }
 
     void Execute();
 }

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -16,6 +16,7 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
     public ILogger Logger { get; set; }
     public string IntermediateDirectoryPath { get; set; }
     public List<string> ReferenceCopyLocalPaths { get; set; }
+    public string DefineConstants { get; set; }
 
     public void Execute()
     {

--- a/FodyIsolated/WeaverDelegateHolder.cs
+++ b/FodyIsolated/WeaverDelegateHolder.cs
@@ -19,5 +19,6 @@ public class WeaverDelegateHolder
     public Action<object, Action<string, SequencePoint>> SetLogErrorPoint;
     public Action<object, Action<string>> SetLogWarning;
     public Action<object, Action<string, SequencePoint>> SetLogWarningPoint;
+    public Action<object, string> SetDefineConstants;
 
 }

--- a/FodyIsolated/WeaverInitialiser.cs
+++ b/FodyIsolated/WeaverInitialiser.cs
@@ -35,6 +35,7 @@ public partial class InnerWeaver
         delegateHolder.SetLogWarningPoint = weaverType.BuildPropertyGetter<Action<string, SequencePoint>>("LogWarningPoint");
         delegateHolder.SetReferenceCopyLocalPaths = weaverType.BuildPropertyGetter<List<string>>("ReferenceCopyLocalPaths");
         delegateHolder.SetSolutionDirectoryPath = weaverType.BuildPropertyGetter<string>("SolutionDirectoryPath");
+        delegateHolder.SetDefineConstants = weaverType.BuildPropertyGetter<string>("DefineConstants");
         return delegateHolder;
     }
 
@@ -78,6 +79,7 @@ public partial class InnerWeaver
         delegateHolder.SetLogInfo(weaverInstance, Logger.LogInfo);
         delegateHolder.SetLogError(weaverInstance, Logger.LogInfo);
         delegateHolder.SetLogErrorPoint(weaverInstance, LogErrorPoint);
+        delegateHolder.SetDefineConstants(weaverInstance, DefineConstants);
     }
 
 


### PR DESCRIPTION
By passing the compile constants to the weavers they can tell if the build is in debug or not.

I need this to implement a fix for Fody/NullGuard#13
