### PR TITLE
Distinguish between update fody issue vs having no references

### DIFF
--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -34,13 +34,12 @@ namespace Fody
 
         public override bool Execute()
         {
-            List<string> referenceCopyLocalPaths = null;
+            var referenceCopyLocalPaths = new List<string>();
             if (ReferenceCopyLocalPaths != null)
             {
                 referenceCopyLocalPaths = ReferenceCopyLocalPaths.Select(x => x.ItemSpec).ToList();
             }
             var defineConstants = new List<string>();
-
             if (DefineConstants != null)
             {
                 defineConstants = DefineConstants.Split(';').ToList();


### PR DESCRIPTION
Currently Costura throws an error if the `ReferenceCopyLocalPaths` list is null. The error says to update Fody so that value is set.

The problem was Fody was up to date, but because I had no references that were copy local Fody was returning null for `ReferenceCopyLocalPaths` anyway.

This should return an empty list if there are no references. So now the states are:
- `ReferenceCopyLocalPaths == null` ERROR: Fody needs to be updated.
- `ReferenceCopyLocalPaths == empty list` There were no copy local references.
- `ReferenceCopyLocalPaths == list with items` The list of copy local references.
