### PR TITLE
Add per-weaver assembly resolve handler

### DIFF
--- a/FodyIsolated/FodyIsolated.csproj
+++ b/FodyIsolated/FodyIsolated.csproj
@@ -77,6 +77,7 @@
     <Compile Include="TypeFinder.cs" />
     <Compile Include="WeaverDelegate.cs" />
     <Compile Include="WeaverInitialiser.cs" />
+    <Compile Include="WeaverDependencyResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FodyCommon\FodyCommon.csproj">

--- a/FodyIsolated/WeaverDependencyResolver.cs
+++ b/FodyIsolated/WeaverDependencyResolver.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+public partial class InnerWeaver
+{
+    ResolveEventHandler CreateAssemblyResolveHandler(string assemblyPath)
+    {
+        var basePath = Path.GetDirectoryName(assemblyPath);
+
+        return (obj, args) =>
+        {
+            try
+            {
+                var assemblyFullName = new AssemblyName(args.Name);
+                var assemblyShortName = assemblyFullName.Name;
+                var location = Path.Combine(basePath, assemblyShortName);
+
+                if (File.Exists(location + ".dll"))
+                {
+                    return Assembly.LoadFile(location + ".dll");
+                }
+
+                if (File.Exists(location + ".exe"))
+                {
+                    return Assembly.LoadFile(location + ".exe");
+                }
+
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
This pull request updates `FodyIsolated.InnerWeaver`'s inner loop such that prior to loading each weaver, a handler is added to `AppDomain.AssemblyResolve` that scans the weaver's directory for unresolved assemblies.  After weaver execution this handler is removed.

This change enables weaver dependencies to live side-by-side with the weaver itself, removing the need to use ILMerge or similar.
