### PR TITLE
Fixed memory leak by ensuring cross appdomain remoting references get de...

### DIFF
--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -144,20 +144,22 @@ public partial class Processor
             appdomain = solutionDomains[SolutionDirectoryPath] = CreateDomain();
         }
 
-        var innerWeaver = (IInnerWeaver) appdomain.CreateInstanceAndUnwrap("FodyIsolated", "InnerWeaver");
-        innerWeaver.AssemblyFilePath = AssemblyFilePath;
-        innerWeaver.References = References;
-        innerWeaver.KeyFilePath = KeyFilePath;
-        innerWeaver.ReferenceCopyLocalPaths = ReferenceCopyLocalPaths;
-        innerWeaver.SignAssembly = SignAssembly;
-        innerWeaver.Logger = Logger;
-        innerWeaver.SolutionDirectoryPath = SolutionDirectoryPath;
-        innerWeaver.Weavers = Weavers;
-        innerWeaver.IntermediateDirectoryPath = IntermediateDirectoryPath;
-        innerWeaver.DefineConstants = DefineConstants;
-        innerWeaver.ProjectDirectoryPath = ProjectDirectory;
-        
-        innerWeaver.Execute();
+        using (var innerWeaver = (IInnerWeaver)appdomain.CreateInstanceAndUnwrap("FodyIsolated", "InnerWeaver"))
+        {
+            innerWeaver.AssemblyFilePath = AssemblyFilePath;
+            innerWeaver.References = References;
+            innerWeaver.KeyFilePath = KeyFilePath;
+            innerWeaver.ReferenceCopyLocalPaths = ReferenceCopyLocalPaths;
+            innerWeaver.SignAssembly = SignAssembly;
+            innerWeaver.Logger = Logger;
+            innerWeaver.SolutionDirectoryPath = SolutionDirectoryPath;
+            innerWeaver.Weavers = Weavers;
+            innerWeaver.IntermediateDirectoryPath = IntermediateDirectoryPath;
+            innerWeaver.DefineConstants = DefineConstants;
+            innerWeaver.ProjectDirectoryPath = ProjectDirectory;
+
+            innerWeaver.Execute();
+        }
     }
 
     AppDomain CreateDomain()

--- a/FodyCommon/IInnerWeaver.cs
+++ b/FodyCommon/IInnerWeaver.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
+using System;
 
-public interface IInnerWeaver
+public interface IInnerWeaver : IDisposable
 {
     string AssemblyFilePath { get; set; }
     string References { get; set; }


### PR DESCRIPTION
...stroyed

Any MarshalByRefObject descendant which returns “null” as the return from their InitializeLifetimeService() will cause a permanent reference to be held open by some fairly low level area in the .NET remoting stack, specifically System.Runtime.Remoting.ServerIdentity (which is marked internal). This was preventing InnerWeaver from being garbage collected, and thus the memory footprint would keep growing and growing.

Another way to deal with this would be to implenent ISponsor, but this becomes easily messier than this fairly clean solution IMO.

My issue was that my IDE/Fody would consequently run out of memory after a few builds of one of my bigger projects (a 20ish solutions) because of Cecil reference dictionaries not getting unloaded (a 60mb of junk per build roughly) 
