### PR TITLE
select newer symbol file if both pdb and mdb exist

### DIFF
--- a/FodyIsolated/SymbolsFinder.cs
+++ b/FodyIsolated/SymbolsFinder.cs
@@ -26,7 +26,17 @@ public partial class InnerWeaver
         mdbPath = AssemblyFilePath + ".mdb";
 		if (File.Exists(mdbPath))
 		{
-		    mdbFound = true;
+			if (pdbFound)
+			{
+				if (File.GetLastWriteTimeUtc(pdbPath) >= File.GetLastWriteTimeUtc(mdbPath))
+				{
+					Logger.LogInfo("Found mdb and pdb debug symbols. Selected pdb (newer).");
+					return;
+				}
+				pdbFound = false;
+				Logger.LogInfo("Found mdb and pdb debug symbols. Selected mdb (newer).");
+			}
+			mdbFound = true;
 		    debugReaderProvider = new MdbReaderProvider();
             debugWriterProvider = new MdbWriterProvider();
 		    Logger.LogInfo(string.Format("Found debug symbols at '{0}'.", mdbPath));


### PR DESCRIPTION
When doing cross-platform (win/*nix) development using VM mapped folders you can get both pdb and mdb debug symbol files in output folder. Fody should grab the one that is newer since that is probably the one generated during last compile (although it might not always be the case, i.e. when clocks of host and guest OS don't match). 

I've changed SymbolsFinder to follow this optimistic selection.
