### PR TITLE
Fixes empty Assembly.CodeBase, causing fatal errors for Fody usage on specific paths

### DIFF
--- a/Fody/AssemblyLocation.cs
+++ b/Fody/AssemblyLocation.cs
@@ -1,12 +1,10 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 
 public static class AssemblyLocation
 {
     public static string CurrentDirectory()
     {
-        Debugger.Launch();
         //Use codebase because location fails for unit tests.
         var assembly = typeof(AssemblyLocation).Assembly;
         var uri = new UriBuilder(string.IsNullOrEmpty(assembly.CodeBase) ? assembly.Location : assembly.CodeBase);


### PR DESCRIPTION
Change: AssemblyLocation class uses Assembly.Location if Assembly.CodeBase is empty.

Some of my colleagues cannot compile projects that have a Fody step. As it turns out, the problem is they have an empty Assembly.CodeBase while the ones that can run have Assembly.CodeBase = Assembly.Location.

First error we got was FodyIsolated.dll not found. .NET was searching the MSBuild path only. When we temporarily placed FodyIsolated.dll next to the MSBuild.exe file, we got another error about Path.Combine having a null parameter.

This commit fixes aforementioned errors.
