### PR TITLE
Logging prefixes at all levels

### DIFF
--- a/Fody/BuildLogger.cs
+++ b/Fody/BuildLogger.cs
@@ -22,17 +22,17 @@ public class BuildLogger : MarshalByRefObject, ILogger
 
     public virtual void LogMessage(string message, MessageImportance level)
     {
-        BuildEngine.LogMessageEvent(new BuildMessageEventArgs(GetIndent() + message, "", "Fody", level));
+        BuildEngine.LogMessageEvent(new BuildMessageEventArgs(GetIndent() + PrependMessage(message), "", "Fody", level));
     }
 
     public virtual void LogDebug(string message)
     {
-        BuildEngine.LogMessageEvent(new BuildMessageEventArgs(GetIndent() + message, "", "Fody", DebugMessageImportant));
+        BuildEngine.LogMessageEvent(new BuildMessageEventArgs(GetIndent() + PrependMessage(message), "", "Fody", DebugMessageImportant));
     }
 
     public virtual void LogInfo(string message)
     {
-        BuildEngine.LogMessageEvent(new BuildMessageEventArgs(GetIndent() + message, "", "Fody", InfoMessageImportant));
+        BuildEngine.LogMessageEvent(new BuildMessageEventArgs(GetIndent() + PrependMessage(message), "", "Fody", InfoMessageImportant));
     }
 
     public virtual void LogWarning(string message)

--- a/FodyIsolated/DelegateBuilders/PropertyDelegateBuilder.cs
+++ b/FodyIsolated/DelegateBuilders/PropertyDelegateBuilder.cs
@@ -11,6 +11,8 @@ public static class PropertyDelegateBuilder
         return action;
     }
 
+    static void EmptySetter<T>(object o, T t) { }
+
     public static bool TryBuildPropertySetDelegate<T>(this Type targetType, string propertyName, out Action<object, T> action)
     {
         var propertyInfo = targetType.GetProperty(propertyName, BindingFlags.SetProperty | BindingFlags.Instance | BindingFlags.Public, null, typeof(T), new Type[] { }, null);
@@ -22,7 +24,7 @@ public static class PropertyDelegateBuilder
             var value = Expression.Parameter(typeof (T));
             var property = Expression.Property(Expression.Convert(target, targetType), setMethod);
             var body = Expression.Assign(property, value);
-            action= Expression.Lambda<Action<object, T>>(body, target, value)
+            action = Expression.Lambda<Action<object, T>>(body, target, value)
                              .Compile();
             return true;
         }
@@ -33,12 +35,12 @@ public static class PropertyDelegateBuilder
             var value = Expression.Parameter(typeof (T), "value");
             var fieldExp = Expression.Field(Expression.Convert(target, targetType), fieldInfo);
             var body = Expression.Assign(fieldExp, value);
-            action= Expression.Lambda<Action<object, T>>(body, target, value)
+            action = Expression.Lambda<Action<object, T>>(body, target, value)
                              .Compile();
             return true;
 
         }
-        action= (x, y) => { };
+        action = EmptySetter;
         return false;
     }
 


### PR DESCRIPTION
A log prefix with the name of the weaver was already done at the warning and error logging level. I just extended this to the Info and Debug levels too.

Also fixes a delegate bug in the tests with Roslyn.