### PR TITLE
Fix weaver project search path in Linux

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -2,5 +2,5 @@
 
 [assembly: AssemblyTitle("Fody")]
 [assembly: AssemblyProduct("Fody")]
-[assembly: AssemblyVersion("1.29.3")]
-[assembly: AssemblyFileVersion("1.29.3")]
+[assembly: AssemblyVersion("1.29.4")]
+[assembly: AssemblyFileVersion("1.29.4")]

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -2,5 +2,5 @@
 
 [assembly: AssemblyTitle("Fody")]
 [assembly: AssemblyProduct("Fody")]
-[assembly: AssemblyVersion("1.29.2")]
-[assembly: AssemblyFileVersion("1.29.2")]
+[assembly: AssemblyVersion("1.29.3")]
+[assembly: AssemblyFileVersion("1.29.3")]

--- a/Fody/WeaverProjectFileFinder.cs
+++ b/Fody/WeaverProjectFileFinder.cs
@@ -24,7 +24,8 @@ public partial class Processor
 
     void GetValue()
     {
-        var weaversBin = Path.Combine(SolutionDirectory, @"Weavers\bin");
+        var weaversBin = Path.Combine(SolutionDirectory, "Weavers", "bin");
+
         if (Directory.Exists(weaversBin))
         {
             WeaverAssemblyPath = Directory.EnumerateFiles(weaversBin, "Weavers.dll", SearchOption.AllDirectories)

--- a/NuGet/Nuget.csproj
+++ b/NuGet/Nuget.csproj
@@ -38,15 +38,12 @@
     <Copy SourceFiles="$(SolutionDir)NuGet\Fody.nuspec" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(SolutionDir)NuGet\FodyWeavers.xml" DestinationFolder="$(SolutionDir)NuGetBuild\Content" />
     <Copy SourceFiles="$(SolutionDir)Fody\bin\$(ConfigurationName)\Fody.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
-    <Copy SourceFiles="$(SolutionDir)Fody\bin\$(ConfigurationName)\Fody.pdb" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(SolutionDir)FodyCommon\bin\$(ConfigurationName)\FodyCommon.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
-    <Copy SourceFiles="$(SolutionDir)FodyCommon\bin\$(ConfigurationName)\FodyCommon.pdb" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(SolutionDir)FodyIsolated\bin\$(ConfigurationName)\FodyIsolated.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
-    <Copy SourceFiles="$(SolutionDir)FodyIsolated\bin\$(ConfigurationName)\FodyIsolated.pdb" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Mdb.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
-    <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Pdb.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Rocks.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
+    <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Pdb.dll" DestinationFolder="$(SolutionDir)NuGetBuild" />
     <Copy SourceFiles="$(ProjectDir)Fody.targets" DestinationFolder="$(SolutionDir)NuGetBuild\build\portable-net+sl+win+wpa+wp" />
     <Copy SourceFiles="$(ProjectDir)Fody.targets" DestinationFolder="$(SolutionDir)NuGetBuild\build\dotnet" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(SolutionDir)NuGetBuild" MetadataAssembly="$(SolutionDir)Fody\bin\$(ConfigurationName)\Fody.dll" />

--- a/NuGetCecil/NugetCecil.csproj
+++ b/NuGetCecil/NugetCecil.csproj
@@ -31,15 +31,11 @@
   <Target Name="ReBuild" DependsOnTargets="NuGetCecilBuild" />
   <Target Name="NuGetCecilBuild" DependsOnTargets="Clean">
     <MakeDir Directories="$(SolutionDir)NuGetCecilBuild" />
-    <Copy SourceFiles="$(SolutionDir)NugetCecil\FodyCecil.nuspec" DestinationFolder="$(SolutionDir)NuGetCecilBuild" />
+    <Copy SourceFiles="$(SolutionDir)NuGetCecil\FodyCecil.nuspec" DestinationFolder="$(SolutionDir)NuGetCecilBuild" />
     <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.dll" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
-    <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.pdb" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
     <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Mdb.dll" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
-    <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Mdb.pdb" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
     <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Pdb.dll" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
-    <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Pdb.pdb" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
     <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Rocks.dll" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
-    <Copy SourceFiles="$(SolutionDir)Lib\Cecil\Mono.Cecil.Rocks.pdb" DestinationFolder="$(SolutionDir)NuGetCecilBuild\lib\net40" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(SolutionDir)NuGetCecilBuild" MetadataAssembly="$(SolutionDir)Fody\bin\$(ConfigurationName)\Fody.dll" />
     <MakeDir Directories="$(SolutionDir)ForSample\build" />
   </Target>


### PR DESCRIPTION
Create the search path in a portable way, since a path with '\' is not valid in Linux and Directory.Exists will always return False.