### PR TITLE
Fix weaver project search path in Linux

### DIFF
--- a/Fody/WeaverProjectFileFinder.cs
+++ b/Fody/WeaverProjectFileFinder.cs
@@ -24,7 +24,8 @@ public partial class Processor
 
     void GetValue()
     {
-        var weaversBin = Path.Combine(SolutionDirectory, @"Weavers\bin");
+        var weaversBin = Path.Combine(SolutionDirectory, "Weavers", "bin");
+
         if (Directory.Exists(weaversBin))
         {
             WeaverAssemblyPath = Directory.EnumerateFiles(weaversBin, "Weavers.dll", SearchOption.AllDirectories)


### PR DESCRIPTION
Create the search path in a portable way, since a path with '\' is not valid in Linux and Directory.Exists will always return False.