### PR TITLE
Fixed setting inherited props on weaver

### DIFF
--- a/FodyIsolated.Tests/DelegateBuilders/PropertyDelegateBuilderTests.cs
+++ b/FodyIsolated.Tests/DelegateBuilders/PropertyDelegateBuilderTests.cs
@@ -2,7 +2,7 @@ using System;
 using NUnit.Framework;
 
 [TestFixture]
-public class PropertyDelegateBuilderTests
+public class PropertyDelegateBuilderTests : BaseClassSupplyingInheritedMembers
 {
     public string Property { get; set; }
 #pragma warning disable 169
@@ -23,7 +23,7 @@ public class PropertyDelegateBuilderTests
         setterDelegate(this, "aString");
         Assert.AreEqual("aString", Property);
     }
-
+    
     [Test]
     public void Should_return_false_for_non_existing()
     {
@@ -38,7 +38,21 @@ public class PropertyDelegateBuilderTests
         setterDelegate(this, "aString");
         Assert.AreEqual("aString",Field);
     }
+    
+    [Test]
+    public void Should_be_able_to_set_inherited_properties() {
+        var setterDelegate = GetType().BuildPropertySetDelegate<string>(nameof(InheritedProperty));
+        setterDelegate(this, "blah");
+        Assert.AreEqual("blah", InheritedProperty);
+    }
 
+    [Test]
+    public void Should_be_able_to_set_inherited_fields() {
+        var setterDelegate = GetType().BuildPropertySetDelegate<string>(nameof(InheritedField));
+        setterDelegate(this, "blah");
+        Assert.AreEqual("blah", InheritedField);
+    }
+    
     [Test]
     public void Should_be_a_null_delegate_When_member_does_not_exist()
     {
@@ -66,5 +80,14 @@ public class PropertyDelegateBuilderTests
         var setterDelegate = GetType().BuildPropertySetDelegate<string>("PrivateProperty");
         Assert.IsNull(setterDelegate.Target);
     }
+    
 
+}
+
+
+
+public class BaseClassSupplyingInheritedMembers
+{
+    public string InheritedProperty { get; set; }
+    public string InheritedField;
 }

--- a/FodyIsolated/DelegateBuilders/PropertyDelegateBuilder.cs
+++ b/FodyIsolated/DelegateBuilders/PropertyDelegateBuilder.cs
@@ -19,10 +19,9 @@ public static class PropertyDelegateBuilder
 
         if (propertyInfo != null)
         {
-            var setMethod = propertyInfo.GetSetMethod();
             var target = Expression.Parameter(typeof (object));
             var value = Expression.Parameter(typeof (T));
-            var property = Expression.Property(Expression.Convert(target, targetType), setMethod);
+            var property = Expression.Property(Expression.Convert(target, targetType), propertyInfo);
             var body = Expression.Assign(property, value);
             action = Expression.Lambda<Action<object, T>>(body, target, value)
                              .Compile();


### PR DESCRIPTION
Hi there,

I'm working on an intermediate add-in to supply further (vaguely planned) add-ins with functionality, and decided the best way to do this would be by ModuleWeaver base class.

I've not completely proved the idea to myself yet, but this was the first hurdle: a slight bug in building the property-setting delegates, which meant that accessors for inherited properties weren't being compiled.

Thanks!