### PR TITLE
ability to select a custom fody xml file

### DIFF
--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -14,6 +14,7 @@ public partial class Processor
     public string ProjectDirectory;
     public string References;
     public string SolutionDirectory;
+    public string CustomFodyFile;
     public string NuGetPackageRoot;
     public List<string> ReferenceCopyLocalPaths;
     public List<string> DefineConstants;
@@ -64,6 +65,11 @@ public partial class Processor
         ValidateAssemblyPath();
 
         ConfigFiles = ConfigFileFinder.FindWeaverConfigs(SolutionDirectory, ProjectDirectory, Logger);
+
+      if (!string.IsNullOrEmpty(CustomFodyFile))
+      {
+         ConfigFiles.Add(CustomFodyFile);
+      }
 
         if (!ShouldStartSinceFileChanged())
         {

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -37,6 +37,8 @@ namespace Fody
 
         public string NuGetPackageRoot { get; set; }
 
+      public string CustomFodyFile { get; set; }
+
         public override bool Execute()
         {
             var referenceCopyLocalPaths = ReferenceCopyLocalPaths.Select(x => x.ItemSpec).ToList();
@@ -56,7 +58,8 @@ namespace Fody
                 SolutionDirectory = SolutionDir,
                 ReferenceCopyLocalPaths = referenceCopyLocalPaths,
                 DefineConstants = defineConstants,
-                NuGetPackageRoot = NuGetPackageRoot
+                NuGetPackageRoot = NuGetPackageRoot,
+                CustomFodyFile = CustomFodyFile
             };
             var success = processor.Execute();
             if (success)

--- a/NuGet/Fody.targets
+++ b/NuGet/Fody.targets
@@ -39,6 +39,7 @@
     <IntermediateDir>$(ProjectDir)$(IntermediateOutputPath)</IntermediateDir>
     <FodySignAssembly Condition="$(FodySignAssembly) == '' Or $(FodySignAssembly) == '*Undefined*'">$(SignAssembly)</FodySignAssembly>
     <FodyPath Condition="$(FodyPath) == '' Or $(FodyPath) == '*Undefined*'">$(MSBuildThisFileDirectory)..\..\</FodyPath>
+    <CustomFodyFile></CustomFodyFile>
   </PropertyGroup>
   <UsingTask
       TaskName="Fody.WeavingTask"
@@ -61,6 +62,7 @@
           References="@(ReferencePath)"
           SignAssembly="$(FodySignAssembly)"
           ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
+          CustomFodyFile="$(CustomFodyFile)"
           DefineConstants="$(DefineConstants)"
       >
 


### PR DESCRIPTION
I'm using costura and I was in need of having two fody xml files. 

For example in `debug` build I need a library to debug, but in release I don't really need this library / dll in my combined exe.

Example to have multiple xml's in csproj:

```
  <Target Name="MyFodyOverrideTarget">
    <Message Text="MyFodyOverrideTarget execute" />
    <Message Text="Old File Path $(CustomFodyFile)" />
    <CreateProperty Value="$(ProjectDir)FodyWeavers.$(Configuration).xml">
      <Output TaskParameter="Value" PropertyName="CustomFodyFile" />
    </CreateProperty>
     <CreateProperty Value="$(ProjectDir)">
      <Output TaskParameter="Value" PropertyName="FodyPath" />
    </CreateProperty>
    <Message Text="New File Path $(CustomFodyFile)" />
  </Target>
  <PropertyGroup>
    <FodyDependsOnTargets>MyFodyOverrideTarget</FodyDependsOnTargets>
  </PropertyGroup>
```
