### PR TITLE
Fix #227 peverify not called

### DIFF
--- a/NuGet/Fody.targets
+++ b/NuGet/Fody.targets
@@ -79,14 +79,14 @@
   <UsingTask
     TaskName="Fody.VerifyTask"
     AssemblyFile="$(FodyPath)\Fody.dll" />
-  <Target Condition="'$(NCrunch)' != '1' And Exists($(TargetPath)) And ('$(FodyWeavingTargetWasRun)' == 'True')"
-      AfterTargets="AfterBuild"
+  <Target Condition="'$(NCrunch)' != '1' And ('$(FodyWeavingTargetWasRun)' == 'True')"
+      AfterTargets="FodyTarget"
       Name="FodyVerifyTarget"
       DependsOnTargets="$(FodyVerifyDependsOnTargets)">
 
     <Fody.VerifyTask
           ProjectDirectory="$(ProjectDir)"
-          TargetPath="$(TargetPath)"
+          TargetPath="@(IntermediateAssembly->'%(FullPath)')"
           SolutionDir="$(FodySolutionDir)"
           DefineConstants="$(DefineConstants)"
       />

--- a/NuGet/Fody.targets
+++ b/NuGet/Fody.targets
@@ -68,18 +68,21 @@
         TaskParameter="ExecutedWeavers"
         PropertyName="FodyExecutedWeavers" />
     </Fody.WeavingTask>
+
+    <PropertyGroup>
+      <FodyWeavingTargetWasRun>True</FodyWeavingTargetWasRun>
+    </PropertyGroup>
+      
   </Target>
 
 
   <UsingTask
     TaskName="Fody.VerifyTask"
     AssemblyFile="$(FodyPath)\Fody.dll" />
-  <Target Condition="'$(NCrunch)' != '1' And Exists($(TargetPath))"
+  <Target Condition="'$(NCrunch)' != '1' And Exists($(TargetPath)) And ('$(FodyWeavingTargetWasRun)' == 'True')"
       AfterTargets="AfterBuild"
       Name="FodyVerifyTarget"
-      DependsOnTargets="$(FodyVerifyDependsOnTargets)"
-      Inputs="@(IntermediateAssembly->'%(FullPath)');$(FodyKeyFilePath);$(ProjectWeaverXml)"
-      Outputs="$(TargetPath)">
+      DependsOnTargets="$(FodyVerifyDependsOnTargets)">
 
     <Fody.VerifyTask
           ProjectDirectory="$(ProjectDir)"


### PR DESCRIPTION
There were two issues both relating to peverify:

1) PeVerify wasn't run at all because of how the target defined the inputs / outputs.

after fixing 1) in the first commit, I noticed another issue:

2) If peverify fails, it correctly fails the build.
But if I then run another incremental build, it just skips the project, because the output file already exists.
I fixed that by scheduling peverify earlier, before the exe/dll was copied from obj to bin.
That way, msbuild will rerun peverify and the build will fail again. 