### PR TITLE
Support running Fody with Code Contracts

### DIFF
--- a/NuGet/Fody.targets
+++ b/NuGet/Fody.targets
@@ -75,6 +75,28 @@
       
   </Target>
 
+  <Target
+      Name="FodyTargetForCodeContracts"
+      AfterTargets="ContractDeclarativeAssembly">
+
+      <Fody.WeavingTask
+          AssemblyPath="@(ContractDeclarativeAssembly->'%(FullPath)')"
+          IntermediateDir="$(IntermediateDir)"
+          KeyFilePath="$(FodyKeyFilePath)"
+          NuGetPackageRoot="$(NuGetPackageRoot)"
+          ProjectDirectory="$(ProjectDir)"
+          SolutionDir="$(FodySolutionDir)"
+          References="@(ReferencePath)"
+          SignAssembly="$(FodySignAssembly)"
+          ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
+          DefineConstants="$(DefineConstants)"
+      >
+
+      <Output
+        TaskParameter="ExecutedWeavers"
+        PropertyName="FodyExecutedWeavers" />
+    </Fody.WeavingTask>
+  </Target>
 
   <UsingTask
     TaskName="Fody.VerifyTask"


### PR DESCRIPTION
If the Code Contracts extension or NuGet package is used in a project, it does an additional compilation stage and produces a secondary assembly for analysis. Fody needs to run against this extra assembly otherwise the Code Contracts analysis stage will flag warnings for things that are potentially resolved by a Fody addin in the primary output assembly.

Fixes #259 
