### PR TITLE
Fix broken generated weaver result

### DIFF
--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -227,7 +227,7 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
         attr.ConstructorArguments.Add(new CustomAttributeArgument(ModuleDefinition.TypeSystem.String,
             FileVersionInfo.GetVersionInfo(typeof(IInnerWeaver).Assembly.Location).FileVersion));
 
-        var td = new TypeDefinition(null, "FodyWeavingResults", TypeAttributes.Class | TypeAttributes.NotPublic);
+        var td = new TypeDefinition(null, "FodyWeavingResults", TypeAttributes.Class | TypeAttributes.NotPublic, ModuleDefinition.ImportReference(typeof(object)));
         td.CustomAttributes.Add(attr);
 
         foreach (var weaver in weaverInstances)


### PR DESCRIPTION
Somewhat recently, Fody has started generating a `FodyWeaverResults` file that doesn't specify a base type which breaks `Assembly.GetTypes()` at runtime.  I tried creating a unit test, but the existing unit test `WeavingInfoTests.WeavedAssembly_ShouldContainWeavedInfo` currently fails, so not sure how to get at the fody-generated assembly for testing purposes.