### PR TITLE
fix for when a weaver has an AfterWeaving method.

### DIFF
--- a/FodyIsolated.Tests/FakeModuleWeaver.cs
+++ b/FodyIsolated.Tests/FakeModuleWeaver.cs
@@ -7,4 +7,8 @@ public class FakeModuleWeaver
     public void Execute()
     {
     }
+
+    public void AfterWeaving()
+    {
+    }
 }

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -90,6 +90,9 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
             if (weaverInstances
                 .Any(_ => _.WeaverDelegate.AfterWeavingExecute != null))
             {
+                ModuleDefinition?.Dispose();
+                SymbolStream?.Dispose();
+
                 ReadModule();
                 WriteModule();
             }


### PR DESCRIPTION
I was working on updating my add-in for jasonwoods-7/Vandelay#2, and I found that when executing the Stamp.Fody add-in, it is throwing the following exception:

```
MSBUILD : error : Fody: An unhandled exception occurred:\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error : Exception:\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error : The process cannot access the file 'R:\home\jwoods\src\git\AssertMessage\Fody\obj\Debug\AssertMessage.Fody.dll.tmp' because it is being used by another process.\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error : StackTrace:\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error :    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error :    at System.IO.File.InternalCopy(String sourceFileName, String destFileName, Boolean overwrite, Boolean checkHost)\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error :    at System.IO.File.Copy(String sourceFileName, String destFileName, Boolean overwrite)\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error :    at InnerWeaver.ReadModule() in C:\projects\fody\FodyIsolated\ModuleReader.cs:line 22\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error :    at InnerWeaver.Execute() in C:\projects\fody\FodyIsolated\InnerWeaver.cs:line 93\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error : Source:\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error : mscorlib\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error : TargetSite:\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error : Void WinIOError(Int32, System.String)\r [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
MSBUILD : error :  [R:\home\jwoods\src\git\AssertMessage\Fody\Fody.csproj]
```

The file copy is failing since the ModuleDefinition field is locking the .tmp file.

To test that this is fixed, I added an AfterWeaving method to FakeModuleWeaver.cs in the FodyIsolated.Tests project. The WeavedAssembly_ShouldContainWeavedInfo test in WeavingInfoTests.cs throws the same exception before applying the two Dispose calls I added to InnerWeaver.cs.