### PR TITLE
Fix Microsoft.Build.BuildEngine.InvalidProjectFileException: Unable t…

### DIFF
--- a/NuGet/Fody.targets
+++ b/NuGet/Fody.targets
@@ -44,7 +44,7 @@
       AssemblyFile="$(FodyPath)\Fody.dll" />
   <Target
       AfterTargets="AfterCompile"
-      Condition="Exists(@(IntermediateAssembly))"
+      Condition="Exists('@(IntermediateAssembly)')"
       Name="FodyTarget"
       DependsOnTargets="$(FodyDependsOnTargets)"
       Inputs="@(IntermediateAssembly->'%(FullPath)');$(FodyKeyFilePath);$(ProjectWeaverXml)"


### PR DESCRIPTION
…o parse condition "Exists(@(IntermediateAssembly))" bug.

It seems that @Exists breaks when the variable inside may contain a period or space in the path. Adding single quotes resolves this issue.
https://github.com/Fody/Fody/issues/305