### PR TITLE
Allow Fody to run even when no debug symbols are present

### DIFF
--- a/FodyIsolated/ModuleReader.cs
+++ b/FodyIsolated/ModuleReader.cs
@@ -8,25 +8,24 @@ public partial class InnerWeaver
 
     public virtual void ReadModule()
     {
-        string symbolsPath;
-        if (pdbFound)
+        var tempAssembly = $"{AssemblyFilePath}.tmp";
+        File.Copy(AssemblyFilePath, tempAssembly, true);
+
+        if (debugReaderProvider != null)
         {
-            symbolsPath = pdbPath;
-        }
-        else
-        {
-            symbolsPath = mdbPath;
+            var symbolsPath = pdbFound ? pdbPath : mdbPath;
+            var tempSymbols = $"{symbolsPath}.tmp";
+            if (File.Exists(symbolsPath))
+            {
+                File.Copy(symbolsPath, tempSymbols, true);
+                SymbolStream = File.OpenRead(tempSymbols);
+            }
         }
 
-        var tempAssembly = $"{AssemblyFilePath}.tmp";
-        var tempSymbols = $"{symbolsPath}.tmp";
-        File.Copy(AssemblyFilePath, tempAssembly,true);
-        File.Copy(symbolsPath, tempSymbols, true);
-        SymbolStream = File.OpenRead(tempSymbols);
         var readerParameters = new ReaderParameters
         {
             AssemblyResolver = assemblyResolver,
-            ReadSymbols = true,
+            ReadSymbols = SymbolStream != null,
             SymbolReaderProvider = debugReaderProvider,
             SymbolStream = SymbolStream,
         };

--- a/FodyIsolated/ModuleWriter.cs
+++ b/FodyIsolated/ModuleWriter.cs
@@ -11,7 +11,7 @@ public partial class InnerWeaver
         var parameters = new WriterParameters
             {
                 StrongNameKeyPair = StrongNameKeyPair,
-                WriteSymbols = true,
+                WriteSymbols = debugWriterProvider != null,
                 SymbolWriterProvider = debugWriterProvider,
             };
 

--- a/FodyIsolated/SymbolsFinder.cs
+++ b/FodyIsolated/SymbolsFinder.cs
@@ -34,7 +34,7 @@ public partial class InnerWeaver
             return;
         }
 
-        throw new WeavingException("Found no debug symbols.");
+        Logger.LogWarning("No debug symbols found. It is recommended to build with debug symbols enabled.");
     }
 
     void ChooseNewest()


### PR DESCRIPTION
Fixes #314, which I needed to test #312 