### PR TITLE
Added DebugSymbols build parameter to Fody

### DIFF
--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -15,6 +15,7 @@ public partial class Processor
     public string References;
     public string SolutionDirectory;
     public string NuGetPackageRoot;
+    public bool DebugSymbols;
     public List<string> ReferenceCopyLocalPaths;
     public List<string> PackageDefinitions;
     public List<string> DefineConstants;
@@ -157,6 +158,7 @@ see https://github.com/Fody/Fody/wiki/SampleUsage");
             innerWeaver.IntermediateDirectoryPath = IntermediateDirectory;
             innerWeaver.DefineConstants = DefineConstants;
             innerWeaver.ProjectDirectoryPath = ProjectDirectory;
+            innerWeaver.DebugSymbols = DebugSymbols;
 
             innerWeaver.Execute();
         }

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -41,6 +41,8 @@ namespace Fody
 
         public string[] PackageDefinitions { get; set; }
 
+        public bool DebugSymbols { get; set; }
+
         public override bool Execute()
         {
             var referenceCopyLocalPaths = ReferenceCopyLocalPaths.Select(x => x.ItemSpec).ToList();
@@ -61,7 +63,8 @@ namespace Fody
                 ReferenceCopyLocalPaths = referenceCopyLocalPaths,
                 DefineConstants = defineConstants,
                 NuGetPackageRoot = NuGetPackageRoot,
-                PackageDefinitions = PackageDefinitions?.ToList()
+                PackageDefinitions = PackageDefinitions?.ToList(),
+                DebugSymbols = DebugSymbols
             };
             var success = processor.Execute();
             if (success)

--- a/FodyCommon/IInnerWeaver.cs
+++ b/FodyCommon/IInnerWeaver.cs
@@ -14,6 +14,7 @@ public interface IInnerWeaver : IDisposable
     List<string> ReferenceCopyLocalPaths { get; set; }
     List<string> DefineConstants { get; set; }
     string ProjectDirectoryPath { get; set; }
+    bool DebugSymbols { get; set; }
 
     void Execute();
     void Cancel();

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -25,6 +25,7 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
     public string IntermediateDirectoryPath { get; set; }
     public List<string> ReferenceCopyLocalPaths { get; set; }
     public List<string> DefineConstants { get; set; }
+    public bool DebugSymbols { get; set; }
     bool cancelRequested;
     List<WeaverHolder> weaverInstances = new List<WeaverHolder>();
     Action cancelDelegate;

--- a/FodyIsolated/SymbolsFinder.cs
+++ b/FodyIsolated/SymbolsFinder.cs
@@ -14,6 +14,12 @@ public partial class InnerWeaver
 
     void GetSymbolProviders()
     {
+        if (!DebugSymbols)
+        {
+            // Log something about building without symbols?
+            return;
+        }
+
         FindPdb();
 
         FindMdb();

--- a/NuGet/Fody.targets
+++ b/NuGet/Fody.targets
@@ -62,6 +62,7 @@
           ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
           DefineConstants="$(DefineConstants)"
           PackageDefinitions="@(PackageDefinitions->'%(ResolvedPath)')"
+          DebugSymbols="$(DebugSymbols)"
       >
 
       <Output 


### PR DESCRIPTION
Passing the `DebugSymbols` flag from MSBuild to fix issue #333 