### PR TITLE
Better symbols detection

### DIFF
--- a/FodyIsolated/SymbolsFinder.cs
+++ b/FodyIsolated/SymbolsFinder.cs
@@ -16,7 +16,7 @@ public partial class InnerWeaver
     {
         if (!DebugSymbols)
         {
-            // Log something about building without symbols?
+            Logger.LogWarning($"Debug symbols are disabled. It is recommended to build with debug symbols enabled.");
             return;
         }
 

--- a/NuGet/Fody.targets
+++ b/NuGet/Fody.targets
@@ -62,7 +62,7 @@
           ReferenceCopyLocalPaths="@(ReferenceCopyLocalPaths)"
           DefineConstants="$(DefineConstants)"
           PackageDefinitions="@(PackageDefinitions->'%(ResolvedPath)')"
-          DebugSymbols="$(DebugSymbols)"
+          DebugSymbols="$(_DebugSymbolsProduced)"
       >
 
       <Output


### PR DESCRIPTION
The `DebugSymbols` MSBuild property can be false or not set even when debug symbols are still being produced, so using the `_DebugSymbolsProduced` property should be used instead to correctly detect when symbols have been created.

Fixes #360 