### PR TITLE
Made logging more verbose for AddInFinder.FindAddinDirectories

### DIFF
--- a/Fody/AddinFinder/AddinSearchDirectories.cs
+++ b/Fody/AddinFinder/AddinSearchDirectories.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,6 +9,8 @@ public partial class AddinFinder
     {
         if (PackageDefinitions == null)
         {
+            Logger.LogDebug("No PackageDefinitions");
+
             AddNugetDirectoryFromConvention();
             AddNugetDirectoryFromNugetConfig();
             AddCurrentFodyDirectoryToAddinSearch();
@@ -16,10 +19,15 @@ public partial class AddinFinder
         }
         else
         {
+            string separator = Environment.NewLine + "    - ";
+            string packageDefinitionsLogMessage = separator + string.Join(separator, PackageDefinitions);
+            Logger.LogDebug($"PackageDefinitions: {packageDefinitionsLogMessage}");
+
             // each PackageDefinition will be of the format C:\...\packages\propertychanging.fody\1.28.0
             // so must be a Contains(.fody)
             foreach (var directory in PackageDefinitions.Where(x => x.ToLowerInvariant().Contains(".fody")))
             {
+                Logger.LogDebug($"Adding weavers from package directory: '{directory}'");
                 AddFiles(Directory.EnumerateFiles(directory, "*.Fody.dll"));
             }
             AddToolsSolutionDirectoryToAddinSearch();


### PR DESCRIPTION
.. to be able to deduce the path the code executes on from the logs.

Downside: As there's no "IfDebugEnabled" on the `ILogger` interface and no `Func<string>` overload it is slightly expensive to log the whole list of PackageDefinitions.