### PR TITLE
Fixed broken sequence Readme.MD chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ Any bugs found must be reproduced in a supported version.
 
 Downstream plugins are recommended to follow the above guidelines.
 
-## Edit and continue
-
-Edit and continue is not supported. There is no extension point to re-weave an assembly after the edit part.
-
-
 ### Reasons
 
 While it may seam trivial to "implement support for earlier versions of.net" the long term support implications are too costly. For example to support earlier versions of .net require 
@@ -38,6 +33,9 @@ While it may seam trivial to "implement support for earlier versions of.net" the
  * Added complexity to setting up build environment.
  * Bugs in unsupported versions in .NET may be manifest as bugs in Fody.
 
+## Edit and continue
+
+Edit and continue is not supported. There is no extension point to re-weave an assembly after the edit part.
 
 ## Project formats
 


### PR DESCRIPTION
Was:
-Supported Runtimes
-Edit & Continue not supported
-- Reasons (=> belongs to "Supported Runtimes")