### PR TITLE
Support for different weaver source

### DIFF
--- a/Fody/InstanceLinker/WeaversConfiguredInstanceLinker.cs
+++ b/Fody/InstanceLinker/WeaversConfiguredInstanceLinker.cs
@@ -1,4 +1,7 @@
 
+using System;
+using System.Linq;
+
 public partial class Processor
 {
     public void ConfigureWhenWeaversFound()
@@ -11,7 +14,16 @@ public partial class Processor
 
     public void ProcessConfig(WeaverEntry weaverConfig)
     {
-        //support for diff names weavers when "In solution weaving"
+        //support for diff names sources
+        if (weaverConfig.Source != null)
+        {
+            weaverConfig.AssemblyPath = References.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(reference => reference.EndsWith($"{weaverConfig.Source}.dll", StringComparison.InvariantCultureIgnoreCase)) ?? throw new WeavingException($"Assembly {weaverConfig.Source} could not be found.");
+            weaverConfig.TypeName = weaverConfig.AssemblyName;
+            WeaverProjectUsed = true;
+            return;
+        }
+
+        //support for diff names weavers when "In solution weaving"        
         var weaverProjectContains = WeaverProjectContainsType(weaverConfig.AssemblyName);
         if (weaverProjectContains)
         {

--- a/Fody/ProjectWeaversReader.cs
+++ b/Fody/ProjectWeaversReader.cs
@@ -31,7 +31,8 @@ public partial class Processor
                 var weaverEntry = new WeaverEntry
                                       {
                                           Element = element.ToString(SaveOptions.OmitDuplicateNamespaces),
-                                          AssemblyName = assemblyName
+                                          AssemblyName = assemblyName,
+                                          Source = element.Attribute("Source")?.Value,
                                       };
                 Weavers.Insert(index, weaverEntry);
             }

--- a/FodyCommon/WeaverEntry.cs
+++ b/FodyCommon/WeaverEntry.cs
@@ -7,4 +7,5 @@ public class WeaverEntry
     public string AssemblyName;
     public string AssemblyPath;
     public string TypeName;
+    public string Source;
 }


### PR DESCRIPTION
See #416

This is a per-weaver configuration.
Before looking for in-solution or "Weavers.dll", Fody will look for an attribute named "Source" in the xml weaver element.

Usage: `<ExampleWeaver Source="ExampleSource"/>`
For this very ExampleWeaver, Fody will look for the first reference of ExampleSource.dll
if there are multiple assemblies named ExampleSource, Fody will only search for the weaver in the first it finds. This means this feature is also affected by #415.