### PR TITLE
Fix #454

### DIFF
--- a/FodyHelpers/BaseModuleWeaver.cs
+++ b/FodyHelpers/BaseModuleWeaver.cs
@@ -110,6 +110,12 @@ namespace Fody
         public List<string> DefineConstants { get; set; }
 
         /// <summary>
+        /// Set to true if this weaver did not modifiy the ModuleDefinition.
+        /// If all weavers set this property to true, Fody will leave the assembly untouched.
+        /// </summary>
+        public bool IsAssemblyUnmodified { get; set; }
+
+        /// <summary>
         /// Called when the weaver is executed.
         /// </summary>
         public abstract void Execute();

--- a/FodyIsolated/DelegateBuilders/DelegateBuilder.cs
+++ b/FodyIsolated/DelegateBuilders/DelegateBuilder.cs
@@ -54,6 +54,7 @@ public static class DelegateBuilder
             SetDocumentationFilePath = weaverType.BuildSetDocumentationFilePath(),
             SetDefineConstants = weaverType.BuildSetDefineConstants(),
             SetFindType = weaverType.BuildSetFindType(),
+            GetIsAssemblyUnmodified = weaverType.BuildIsAssemblyUnmodifiedDelegate(),
             GetAssembliesForScanning = weaverType.BuildGetAssembliesForScanningDelegate(),
             ConstructInstance = weaverType.BuildConstructorDelegate()
         };

--- a/FodyIsolated/ModuleWriter.cs
+++ b/FodyIsolated/ModuleWriter.cs
@@ -1,10 +1,16 @@
 using System.Diagnostics;
+using System.Linq;
 using Mono.Cecil;
 
 public partial class InnerWeaver
 {
     public virtual void WriteModule()
     {
+        if (weaverInstances.All(weaver => weaver.WeaverDelegate.GetIsAssemblyUnmodified(weaver.Instance)))
+        {
+            Logger.LogDebug("  No weaver modified the assembly, skipping write");
+            return;
+        }
         var stopwatch = Stopwatch.StartNew();
         Logger.LogDebug($"  Writing assembly to '{AssemblyFilePath}'.");
 

--- a/FodyIsolated/WeaverDelegate.cs
+++ b/FodyIsolated/WeaverDelegate.cs
@@ -29,6 +29,7 @@ public class WeaverDelegate
     public Action<object, Action<string>> SetLogWarning;
     public Action<object, Action<string, SequencePoint>> SetLogWarningPoint;
     public Action<object, List<string>> SetDefineConstants;
+    public Func<object, bool> GetIsAssemblyUnmodified;
     public Func<object> ConstructInstance;
     public Action<object, Func<string, TypeDefinition>> SetFindType;
     public Func<object, IEnumerable<string>> GetAssembliesForScanning;

--- a/Tests/FodyIsolated/DelegateBuilders/PropertyDelegateBuilderTests.cs
+++ b/Tests/FodyIsolated/DelegateBuilders/PropertyDelegateBuilderTests.cs
@@ -74,6 +74,76 @@ public class PropertyDelegateBuilderTests : TestBase
         Assert.Null(setterDelegate.Target);
     }
 
+    [Fact]
+    public void Should_be_able_to_get_a_public_property_via_a_constructed_delegate()
+    {
+        var target = new Target { Property = "aString" };
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>("Property");
+        string value = getterDelegate(target);
+        Assert.Equal(target.Property, value);
+    }
+
+    [Fact]
+    public void Getter_should_return_false_for_non_existing()
+    {
+        Assert.False(typeof(Target).TryBuildPropertyGetDelegate("NonExisting", out Func<object, string> getterDelegate));
+    }
+
+    [Fact]
+    public void Should_be_able_to_get_a_public_field_via_a_constructed_delegate()
+    {
+        var target = new Target { Field = "aString" };
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>("Field");
+        string value = getterDelegate(target);
+        Assert.Equal(target.Field, value);
+    }
+
+    [Fact]
+    public void Should_be_able_to_get_inherited_properties()
+    {
+        var target = new Target { InheritedProperty = "blah" };
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>(nameof(Target.InheritedProperty));
+        string value = getterDelegate(target);
+        Assert.Equal(target.InheritedProperty, value);
+    }
+
+    [Fact]
+    public void Should_be_able_to_get_inherited_fields()
+    {
+        var target = new Target { InheritedField = "blah" };
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>(nameof(Target.InheritedField));
+        string value = getterDelegate(target);
+        Assert.Equal(target.InheritedField, value);
+    }
+
+    [Fact]
+    public void Should_be_a_null_getter_delegate_When_member_does_not_exist()
+    {
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>("BadProperty");
+        Assert.Null(getterDelegate.Target);
+    }
+
+    [Fact]
+    public void Should_be_a_null_getter_delegate_When_private_property()
+    {
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>("privateField");
+        Assert.Null(getterDelegate.Target);
+    }
+
+    [Fact]
+    public void Should_be_a_null_getter_delegate_When_static_field()
+    {
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>("StaticField");
+        Assert.Null(getterDelegate.Target);
+    }
+
+    [Fact]
+    public void Should_be_a_null_getter_delegate_When_private_field()
+    {
+        var getterDelegate = typeof(Target).BuildPropertyGetDelegate<string>("PrivateProperty");
+        Assert.Null(getterDelegate.Target);
+    }
+
     public class BaseClassSupplyingInheritedMembers
     {
         public string InheritedProperty { get; set; }

--- a/Tests/FodyIsolated/IsAssemblyUnmodifiedTests.cs
+++ b/Tests/FodyIsolated/IsAssemblyUnmodifiedTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+using Moq;
+using Xunit;
+
+public class IsAssemblyUnmodifiedTests : TestBase, IDisposable
+{
+    string tempFilePath;
+    string tempPdbFilePath;
+
+    public IsAssemblyUnmodifiedTests()
+    {
+        var assemblyFilePath = $@"{AssemblyLocation.CurrentDirectory}\DummyAssembly.dll";
+        var pdbFilePath = $@"{AssemblyLocation.CurrentDirectory}\DummyAssembly.pdb";
+        tempFilePath = $@"{AssemblyLocation.CurrentDirectory}\Temp.dll";
+        tempPdbFilePath = $@"{AssemblyLocation.CurrentDirectory}\Temp.pdb";
+        File.Copy(assemblyFilePath, tempFilePath, true);
+        File.Copy(pdbFilePath, tempPdbFilePath, true);
+    }
+
+    [Fact]
+    public void WeavedAssembly_ShouldNotBeWrittenIfUnmodified()
+    {
+        using (var innerWeaver = new InnerWeaver
+        {
+            References = string.Empty,
+            Logger = new Mock<ILogger>().Object,
+            AssemblyFilePath = tempFilePath,
+            DefineConstants = new List<string>
+            {
+                "Debug",
+                "Release"
+            },
+            Weavers = new List<WeaverEntry>
+            {
+                new WeaverEntry
+                {
+                    TypeName = nameof(NonModifyingFakeModuleWeaver),
+                    AssemblyName = "FodyIsolated.Tests",
+                    AssemblyPath = $@"{AssemblyLocation.CurrentDirectory}\Tests.dll"
+                }
+            },
+        })
+        {
+            innerWeaver.Execute();
+        }
+
+        using (var readModule = ModuleDefinition.ReadModule(tempFilePath))
+        {
+            var type = readModule.Types
+                .FirstOrDefault(_ => _.Name == "ProcessedByFody");
+            Assert.Null(type);
+        }
+    }
+
+    public void Dispose()
+    {
+        File.Delete(tempFilePath);
+        File.Delete(tempPdbFilePath);
+    }
+}

--- a/Tests/FodyIsolated/NonModifyingFakeModuleWeaver.cs
+++ b/Tests/FodyIsolated/NonModifyingFakeModuleWeaver.cs
@@ -1,0 +1,17 @@
+﻿using Mono.Cecil;
+
+
+public class NonModifyingFakeModuleWeaver
+{
+    public ModuleDefinition ModuleDefinition { get; set; }
+
+    public bool IsAssemblyUnmodified { get; } = true;
+
+    public void Execute()
+    {
+    }
+
+    public void AfterWeaving()
+    {
+    }
+}


### PR DESCRIPTION
Fixes #454 

Adding a new property that weavers can set to indicate that they did not modify the assembly. If all weavers set this to true, the assembly will not be re-written.
  