### PR TITLE
Filter weavers by version number

### DIFF
--- a/Fody/AddinFinder/AddinFilesEnumerator.cs
+++ b/Fody/AddinFinder/AddinFilesEnumerator.cs
@@ -2,16 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Fody;
 
 public partial class AddinFinder
 {
     public List<string> FodyFiles = new List<string>();
 
-    public string FindAddinAssembly(string packageName)
+    public string FindAddinAssembly(string packageName, VersionFilter versionFilter)
     {
         var packageFileName = packageName + ".Fody.dll";
-        return FodyFiles.Where(x => string.Equals(Path.GetFileName(x), packageFileName, StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(AssemblyVersionReader.GetAssemblyVersion)
-            .FirstOrDefault();
+        return (from file in FodyFiles
+                where string.Equals(Path.GetFileName(file), packageFileName, StringComparison.OrdinalIgnoreCase)
+                let version = AssemblyVersionReader.GetAssemblyVersion(file)
+                where versionFilter == null || versionFilter.IsMatch(version)
+                orderby version descending
+                select file).FirstOrDefault();
     }
 }

--- a/Fody/InstanceLinker/WeaversConfiguredInstanceLinker.cs
+++ b/Fody/InstanceLinker/WeaversConfiguredInstanceLinker.cs
@@ -21,7 +21,7 @@ public partial class Processor
             return;
         }
 
-        var assemblyPath = FindAssemblyPath(weaverConfig.AssemblyName);
+        var assemblyPath = FindAssemblyPath(weaverConfig.AssemblyName, VersionFilter.Parse(weaverConfig.VersionFilter));
         if (assemblyPath == null)
         {
             var message = string.Format(

--- a/Fody/ProjectWeaversReader.cs
+++ b/Fody/ProjectWeaversReader.cs
@@ -7,6 +7,7 @@ using Fody;
 
 public partial class Processor
 {
+    private const string WeaverVersionAttribute = "WeaverVersion";
     public List<WeaverEntry> Weavers;
 
     public virtual void ReadProjectWeavers()
@@ -31,6 +32,7 @@ public partial class Processor
                 }
                 var weaverEntry = new WeaverEntry
                                       {
+                                          VersionFilter = element.Attribute(WeaverVersionAttribute)?.Value,
                                           Element = element.ToString(SaveOptions.OmitDuplicateNamespaces),
                                           AssemblyName = assemblyName
                                       };

--- a/Fody/VersionFilter.cs
+++ b/Fody/VersionFilter.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Fody
+{
+    public class VersionFilter
+    {
+        private readonly Version _minimum;
+        private readonly Version _maximum;
+        private readonly bool _minimumInclusive;
+        private readonly bool _maximumInclusive;
+
+        public static VersionFilter Parse(string filterString)
+        {
+            if (string.IsNullOrWhiteSpace(filterString)) return null;
+
+            string[] parts = filterString.Split(',');
+            string minString, maxString;
+            bool minInclusive = true, maxInclusive = true;
+            switch (parts.Length)
+            {
+                case 1:
+                    minString = maxString = parts[0];
+                    break;
+                case 2:
+                    minString = parts[0];
+                    maxString = parts[1];
+
+                    break;
+                default:
+                    throw new Exception($"'{filterString}' is not a valid version filter string");
+            }
+
+            if (minString.StartsWith("(", StringComparison.Ordinal))
+            {
+                minInclusive = false;
+            }
+
+            if (maxString.EndsWith(")", StringComparison.Ordinal))
+            {
+                maxInclusive = false;
+            }
+
+            minString = minString.TrimStart('(', '[').Trim();
+            maxString = maxString.TrimEnd(')', ']').Trim();
+
+            try
+            {
+                return new VersionFilter(new Version(minString), new Version(maxString), minInclusive, maxInclusive);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"'{filterString}' is not a valid version filter string", e);
+            }
+        }
+
+        private VersionFilter(Version minimum, Version maximum, bool minimumInclusive, bool maximumInclusive)
+        {
+            _minimum = minimum;
+            _maximum = maximum;
+            _minimumInclusive = minimumInclusive;
+            _maximumInclusive = maximumInclusive;
+        }
+
+        public bool IsMatch(System.Version version)
+        {
+            if (_minimumInclusive ? version < _minimum : version <= _minimum)
+            {
+                return false;
+            }
+
+            if (_maximumInclusive ? version > _maximum : version >= _maximum)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return $"{(_minimumInclusive ? "[" : "(")}{_minimum},{_maximum}{(_maximumInclusive ? "]" : ")")}";
+        }
+
+        private class Version
+        {
+            private readonly int? _major;
+            private readonly int? _minor;
+            private readonly int? _build;
+            private readonly int? _revision;
+
+            public Version(string version)
+            {
+                if (string.IsNullOrWhiteSpace(version))
+                    return;
+
+                string[] parts = version.Split('.');
+                switch (parts.Length)
+                {
+                    case 4:
+                        _revision = ParseValue(parts[3]);
+                        goto case 3;
+                    case 3:
+                        _build = ParseValue(parts[2]);
+                        goto case 2;
+                    case 2:
+                        _minor = ParseValue(parts[1]);
+                        goto case 1;
+                    case 1:
+                        _major = ParseValue(parts[0]);
+                        break;
+                    default: throw new Exception();
+                }
+
+                int? ParseValue(string value)
+                {
+                    if (string.Equals("*", value, StringComparison.Ordinal))
+                        return null;
+                    return int.Parse(value);
+                }
+            }
+
+            public override string ToString()
+            {
+                return string.Join(".", GetParts());
+                IEnumerable<string> GetParts()
+                {
+                    if (_major != null)
+                    {
+                        yield return _major.Value.ToString();
+                        if (_minor != null)
+                        {
+                            yield return _minor.Value.ToString();
+                            if (_build != null)
+                            {
+                                yield return _build.Value.ToString();
+                                if (_revision != null)
+                                {
+                                    yield return _revision.Value.ToString();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            public static bool operator >(System.Version a, Version b)
+            {
+                if (a.Major > b._major)
+                    return true;
+                if (a.Major != b._major) return false;
+
+                if (a.Minor > b._minor)
+                    return true;
+                if (a.Minor != b._minor) return false;
+
+                if (a.Build > b._build)
+                    return true;
+                if (a.Build != b._build) return false;
+
+                if (a.Revision > b._revision)
+                    return true;
+
+                return false;
+            }
+
+            public static bool operator <(System.Version a, Version b)
+            {
+                if (a.Major < b._major)
+                    return true;
+                if (a.Major != b._major) return false;
+
+                if (a.Minor < b._minor)
+                    return true;
+                if (a.Minor != b._minor) return false;
+
+                if (a.Build < b._build)
+                    return true;
+                if (a.Build != b._build) return false;
+
+                if (a.Revision < b._revision)
+                    return true;
+                return false;
+            }
+
+            public static bool operator >=(System.Version a, Version b)
+            {
+                if (a.Major >= b._major)
+                    return true;
+                if (a.Minor >= b._minor)
+                    return true;
+                if (a.Build >= b._build)
+                    return true;
+                if (a.Revision >= b._revision)
+                    return true;
+                return false;
+            }
+
+            public static bool operator <=(System.Version a, Version b)
+            {
+                if (a.Major <= b._major)
+                    return true;
+                if (a.Minor <= b._minor)
+                    return true;
+                if (a.Build <= b._build)
+                    return true;
+                if (a.Revision <= b._revision)
+                    return true;
+                return false;
+            }
+        }
+    }
+}

--- a/Fody/WeaverAssemblyPathFinder.cs
+++ b/Fody/WeaverAssemblyPathFinder.cs
@@ -1,9 +1,11 @@
 
+using Fody;
+
 public partial class Processor
 {
-    public virtual string FindAssemblyPath(string weaverName)
+    public virtual string FindAssemblyPath(string weaverName, VersionFilter filter)
     {
-        var assemblyPath = addinFinder.FindAddinAssembly(weaverName);
+        var assemblyPath = addinFinder.FindAddinAssembly(weaverName, filter);
         if (assemblyPath != null)
         {
             if (ContainsTypeChecker.Check(assemblyPath, "ModuleWeaver"))

--- a/FodyCommon/WeaverEntry.cs
+++ b/FodyCommon/WeaverEntry.cs
@@ -3,6 +3,7 @@ using System;
 [Serializable]
 public class WeaverEntry
 {
+    public string VersionFilter;
     public string Element;
     public string AssemblyName;
     public string AssemblyPath;

--- a/Tests/Fody/AddinFinderTest/AddinFinderTest.cs
+++ b/Tests/Fody/AddinFinderTest/AddinFinderTest.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using Fody;
 using Xunit;
 using ObjectApproval;
 
@@ -37,7 +38,18 @@ public class AddinFinderTest : TestBase
         Verify(combine);
     }
 
-    static void Verify(string combine)
+    [Fact(Skip = "Need valid weavers dlls, or better mocking")]
+    public void WhenVersionFilterIsSpecifiedItLimitsMatchedWeavers()
+    {
+        var addinFinder = new AddinFinder(null, null, null, null, null);
+        addinFinder.FodyFiles.Add("");
+        var filter = VersionFilter.Parse("[1.0.7, 1.0.8)");
+
+        string found = addinFinder.FindAddinAssembly("Weaver1", filter);
+        Assert.Equal("", found);
+    }
+
+    private static void Verify(string combine)
     {
         var addinFinder = new AddinFinder(
             log: s => { },

--- a/Tests/Fody/InstanceLinker/WeaversConfiguredInstanceLinkerTests.cs
+++ b/Tests/Fody/InstanceLinker/WeaversConfiguredInstanceLinkerTests.cs
@@ -30,7 +30,7 @@ public class WeaversConfiguredInstanceLinkerTests : TestBase
         var mock = new Mock<Processor>();
         mock.Setup(x => x.WeaverProjectContainsType("AddinName"))
             .Returns(false);
-        mock.Setup(x => x.FindAssemblyPath("AddinName")).Returns("Path");
+        mock.Setup(x => x.FindAssemblyPath("AddinName", null)).Returns("Path");
 
         mock.CallBase = true;
 

--- a/Tests/Fody/ProjectWeaversReaderTests/FodyWeavers4.xml
+++ b/Tests/Fody/ProjectWeaversReaderTests/FodyWeavers4.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Weavers >
+  <SampleTask1 WeaverVersion="1.2.3"/>
+  <SampleTask2 WeaverVersion="(1.2.3, 4.5.*]"/>
+  <SampleTask3 />
+</Weavers>

--- a/Tests/Fody/ProjectWeaversReaderTests/ProjectWeaversReaderTests.cs
+++ b/Tests/Fody/ProjectWeaversReaderTests/ProjectWeaversReaderTests.cs
@@ -23,6 +23,25 @@ public class ProjectWeaversReaderTests : TestBase
         Assert.Equal("<SampleTask3 MyProperty3=\"PropertyValue3\" />", weavers[2].Element);
     }
 
+    [Fact]
+    public void ItLoadsWeaverVersionFilters()
+    {
+        var currentDirectory = AssemblyLocation.CurrentDirectory;
+        var processor = new Processor
+        {
+            ConfigFiles = new List<string>
+            {
+                Path.Combine(currentDirectory, @"Fody\ProjectWeaversReaderTests\FodyWeavers4.xml")
+            }
+        };
+        processor.ReadProjectWeavers();
+        var weavers = processor.Weavers;
+        Assert.Equal(3, weavers.Count);
+        Assert.Equal("1.2.3", weavers[0].VersionFilter);
+        Assert.Equal("(1.2.3, 4.5.*]", weavers[1].VersionFilter);
+        Assert.True(string.IsNullOrWhiteSpace(weavers[2].VersionFilter));
+    }
+
     static IEnumerable<string> GetPaths()
     {
         var currentDirectory = AssemblyLocation.CurrentDirectory;

--- a/Tests/Fody/VersionFilterTests.cs
+++ b/Tests/Fody/VersionFilterTests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using Fody;
+using Xunit;
+
+namespace Tests.Fody
+{
+    public class VersionFilterTests
+    {
+        [Fact]
+        public void When_major_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1");
+
+            Assert.True(filter.IsMatch(new Version(1, 0)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2, 3)));
+            Assert.False(filter.IsMatch(new Version(2, 0)));
+            Assert.False(filter.IsMatch(new Version(0, 0)));
+        }
+
+        [Fact]
+        public void When_major_and_minor_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2, 3)));
+            Assert.False(filter.IsMatch(new Version(1, 2)));
+            Assert.False(filter.IsMatch(new Version(1, 0)));
+        }
+
+        [Fact]
+        public void When_major_minor_and_build_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1.1");
+
+            Assert.True(filter.IsMatch(new Version(1, 1, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 1, 2)));
+            Assert.False(filter.IsMatch(new Version(1, 1, 0)));
+            Assert.False(filter.IsMatch(new Version(1, 1, 0)));
+        }
+
+        [Fact]
+        public void When_major_minor_build_and_revision_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1.1.1");
+            
+            Assert.True(filter.IsMatch(new Version(1, 1, 1, 1)));
+            Assert.False(filter.IsMatch(new Version(1, 1, 1, 0)));
+            Assert.False(filter.IsMatch(new Version(1, 1, 1, 2)));
+        }
+
+        [Fact]
+        public void When_major_and_wildcard_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.*");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2, 3)));
+            Assert.False(filter.IsMatch(new Version(2, 0)));
+            Assert.False(filter.IsMatch(new Version(0, 9)));
+        }
+
+        [Fact]
+        public void When_major_minor_and_wildcard_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1.*");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 2, 3)));
+            Assert.False(filter.IsMatch(new Version(1, 2)));
+            Assert.False(filter.IsMatch(new Version(1, 0)));
+        }
+
+        [Fact]
+        public void When_major_minor_build_and_wildcard_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1.1.*");
+
+            Assert.True(filter.IsMatch(new Version(1, 1, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 1, 1, 2)));
+            Assert.False(filter.IsMatch(new Version(1, 1, 0)));
+            Assert.False(filter.IsMatch(new Version(1, 1, 0)));
+        }
+
+        [Fact]
+        public void When_implicit_inclusive_range_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1,2.0.1");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(2, 0, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 9, 9)));
+            Assert.False(filter.IsMatch(new Version(1, 0)));
+            Assert.False(filter.IsMatch(new Version(2, 0, 2)));
+        }
+
+        [Fact]
+        public void When_explicit_inclusive_range_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("[1.1, 2.0.1]");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(2, 0, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 9, 9)));
+            Assert.False(filter.IsMatch(new Version(1, 0)));
+            Assert.False(filter.IsMatch(new Version(2, 0, 2)));
+        }
+
+        [Fact]
+        public void When_implicit_unbound_max_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1,");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(2, 0, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 9, 9)));
+            Assert.False(filter.IsMatch(new Version(1, 0)));
+        }
+
+        [Fact]
+        public void When_explicit_unbound_max_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("1.1,*");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(2, 0, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 9, 9)));
+            Assert.False(filter.IsMatch(new Version(1, 0)));
+        }
+
+        [Fact]
+        public void When_implicit_unbound_min_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse(",2.0");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(2, 0, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 9, 9)));
+            Assert.False(filter.IsMatch(new Version(2, 1)));
+        }
+
+        [Fact]
+        public void When_explicit_unbound_min_version_is_specified_it_matchs()
+        {
+            VersionFilter filter = VersionFilter.Parse("*,2.0");
+
+            Assert.True(filter.IsMatch(new Version(1, 1)));
+            Assert.True(filter.IsMatch(new Version(2, 0, 1)));
+            Assert.True(filter.IsMatch(new Version(1, 9, 9)));
+            Assert.False(filter.IsMatch(new Version(2, 1)));
+        }
+    }
+}

--- a/Tests/Fody/WeaverAssemblyPathFinderTests.cs
+++ b/Tests/Fody/WeaverAssemblyPathFinderTests.cs
@@ -11,6 +11,6 @@ public class WeaverAssemblyPathFinderTests : TestBase
         {
             ContainsTypeChecker = new Mock<ContainsTypeChecker>().Object,
         };
-        finder.FindAssemblyPath("Name");
+        finder.FindAssemblyPath("Name", null);
     }
 }


### PR DESCRIPTION
Adding the ability to filter which version of a weaver gets loaded by specifying a "WeaverVersion" attribute as part of the weaver's element in the FodyWeavers.xml. Versions numbers can be specified as individual version numbers (including wild cards; "1.2.3.*"), or as a range ("[1.2.3, 2.*)").

This is technically a breaking change for anyone who was previously using this attribute for their own purpose (unlikely).

I find the current behavior especially problematic on repositories where the packages directory is not checked in. When switching between branches where different version of the weaver are expected to be used, Fody always grabs the latest version which forces me to clear previous versions of the weaver just to build my projects correctly. This would allow specifying the appropriate version in the FodyWeavers.xml so that the code in each branch of my project would use the appropriate weaver version.