### PR TITLE
Try to get the real assembly name in AssemblyResolver

### DIFF
--- a/FodyIsolated/AssemblyResolver.cs
+++ b/FodyIsolated/AssemblyResolver.cs
@@ -15,13 +15,13 @@ public class AssemblyResolver : IAssemblyResolver
     {
     }
 
-    public AssemblyResolver(ILogger logger, List<string> splitReferences)
+    public AssemblyResolver(ILogger logger, IEnumerable<string> splitReferences)
     {
         referenceDictionary = new Dictionary<string, string>();
         this.logger = logger;
-        this.splitReferences = splitReferences;
+        this.splitReferences = splitReferences.ToList();
 
-        foreach (var filePath in splitReferences)
+        foreach (var filePath in this.splitReferences)
         {
             referenceDictionary[GetAssemblyName(filePath)] = filePath;
         }

--- a/FodyIsolated/AssemblyResolver.cs
+++ b/FodyIsolated/AssemblyResolver.cs
@@ -23,7 +23,20 @@ public class AssemblyResolver : IAssemblyResolver
 
         foreach (var filePath in splitReferences)
         {
-            referenceDictionary[Path.GetFileNameWithoutExtension(filePath)] = filePath;
+            referenceDictionary[GetAssemblyName(filePath)] = filePath;
+        }
+    }
+
+    private string GetAssemblyName(string filePath)
+    {
+        try
+        {
+            return GetAssembly(filePath, new ReaderParameters(ReadingMode.Deferred)).Name.Name;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug($"Could not load {filePath}, assuming the assembly name is equal to the file name: {ex}");
+            return Path.GetFileNameWithoutExtension(filePath);
         }
     }
 

--- a/Tests/FodyCommon/NullLogger.cs
+++ b/Tests/FodyCommon/NullLogger.cs
@@ -1,0 +1,38 @@
+﻿public class NullLogger : ILogger
+{
+    public void SetCurrentWeaverName(string weaverName)
+    {
+    }
+
+    public void ClearWeaverName()
+    {
+    }
+
+    public void LogDebug(string message)
+    {
+    }
+
+    public void LogInfo(string message)
+    {
+    }
+
+    public void LogMessage(string message, int level)
+    {
+    }
+
+    public void LogWarning(string message)
+    {
+    }
+
+    public void LogWarning(string message, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber)
+    {
+    }
+
+    public void LogError(string message, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber)
+    {
+    }
+
+    public void LogError(string message)
+    {
+    }
+}

--- a/Tests/FodyIsolated/AssemblyResolverTests.cs
+++ b/Tests/FodyIsolated/AssemblyResolverTests.cs
@@ -28,14 +28,14 @@ public class AssemblyResolverTests : TestBase
     }
 
     [Fact]
-    private void ShouldReturnNullWhenTheAssemblyIsNotFound()
+    void ShouldReturnNullWhenTheAssemblyIsNotFound()
     {
         var resolver = new AssemblyResolver(new NullLogger(), Enumerable.Empty<string>());
         Assert.Null(resolver.Resolve("SomeNonExistingAssembly"));
     }
 
     [Fact]
-    private void ShouldGuessTheAssemblyNameFromTheFileNameIfTheAssemblyCannotBeLoaded()
+    void ShouldGuessTheAssemblyNameFromTheFileNameIfTheAssemblyCannotBeLoaded()
     {
         var resolver = new AssemblyResolver(new NullLogger(), new[] {Path.Combine(AssemblyLocation.CurrentDirectory, @"Fody\BadAssembly.dll")});
         Assert.ThrowsAny<Exception>(() => resolver.Resolve("BadAssembly"));

--- a/Tests/FodyIsolated/AssemblyResolverTests.cs
+++ b/Tests/FodyIsolated/AssemblyResolverTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using DummyAssembly;
+using Xunit;
+
+public class AssemblyResolverTests : TestBase
+{
+    [Fact]
+    public void ShouldFindReferenceByAssemblyName()
+    {
+        var assemblyPath = Path.GetTempFileName();
+        try
+        {
+            var assembly = typeof(Class1).Assembly;
+            File.Copy(assembly.Location, assemblyPath, true);
+
+            var resolver = new AssemblyResolver(new NullLogger(), new[] {assemblyPath});
+            using (var resolvedAssembly = resolver.Resolve(assembly.GetName().Name))
+            {
+                Assert.Equal(assembly.FullName, resolvedAssembly.FullName);
+            }
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+    }
+
+    [Fact]
+    private void ShouldReturnNullWhenTheAssemblyIsNotFound()
+    {
+        var resolver = new AssemblyResolver(new NullLogger(), Enumerable.Empty<string>());
+        Assert.Null(resolver.Resolve("SomeNonExistingAssembly"));
+    }
+
+    [Fact]
+    private void ShouldGuessTheAssemblyNameFromTheFileNameIfTheAssemblyCannotBeLoaded()
+    {
+        var resolver = new AssemblyResolver(new NullLogger(), new[] {Path.Combine(AssemblyLocation.CurrentDirectory, @"Fody\BadAssembly.dll")});
+        Assert.ThrowsAny<Exception>(() => resolver.Resolve("BadAssembly"));
+    }
+}


### PR DESCRIPTION
AssemblyResolver assumes the assembly name is always equal to the file name. This leads to issues such as  https://github.com/Fody/PropertyChanged/pull/181
This PR causes the resolver to attempt to read the assembly identity from the given file before falling back to this assumption.
