### PR TITLE
fixes #501 [WIP]

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>2.4.6</Version>
+    <Version>2.4.7</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <NoWarn>CS1591</NoWarn>

--- a/Fody/ConfigFileFinder.cs
+++ b/Fody/ConfigFileFinder.cs
@@ -1,19 +1,25 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Fody;
 
 public class ConfigFileFinder
 {
-    public static List<string> FindWeaverConfigs(string solutionDirectoryPath, string projectDirectory, ILogger logger)
+    private static void AddIfFileExists(List<string> configFiles, string configFilePath, ILogger logger, bool logNotFound = false)
+    {
+        if (File.Exists(configFilePath))
+        {
+            configFiles.Add(configFilePath);
+            logger.LogDebug($"Found path to weavers file '{configFilePath}'.");
+        }
+        else if (logNotFound)
+        {
+            logger.LogWarning($"Unable to find weavers file '{configFilePath}'.");
+        }
+    }
+    public static List<string> FindWeaverConfigs(string projectDirectory, ILogger logger, IEnumerable<string> directoriesToSearchIn = null, IEnumerable<string> configFilePaths = null)
     {
         var files = new List<string>();
-
-        var solutionConfigFilePath = Path.Combine(solutionDirectoryPath, "FodyWeavers.xml");
-        if (File.Exists(solutionConfigFilePath))
-        {
-            files.Add(solutionConfigFilePath);
-            logger.LogDebug($"Found path to weavers file '{solutionConfigFilePath}'.");
-        }
 
         var projectConfigFilePath = Path.Combine(projectDirectory, "FodyWeavers.xml");
         if (!File.Exists(projectConfigFilePath))
@@ -30,11 +36,36 @@ public class ConfigFileFinder
             logger.LogDebug($"Found path to weavers file '{projectConfigFilePath}'.");
         }
 
+        if (directoriesToSearchIn != null)
+        {
+            foreach (var directory in directoriesToSearchIn)
+            {
+                var configFilePath = Path.Combine(directory, "FodyWeavers.xml");
+                AddIfFileExists(files, configFilePath, logger);
+            }
+        }
+
+        if (configFilePaths != null)
+        {
+            foreach (var configFilePath in configFilePaths)
+            {
+                AddIfFileExists(files, configFilePath, logger, true);
+            }
+        }
+
         if (files.Count == 0)
         {
-            var pathsSearched = string.Join("', '", solutionConfigFilePath, projectConfigFilePath);
-            throw new WeavingException($"Could not find path to weavers file. Searched '{pathsSearched}'.");
+            IEnumerable<string> pathsSearched = new[] { projectConfigFilePath };
+            if (directoriesToSearchIn != null)
+                pathsSearched = pathsSearched.Union(directoriesToSearchIn);
+            if (configFilePaths != null)
+                pathsSearched = pathsSearched.Union(configFilePaths);
+            var pathsSearchedString = string.Join("', '", pathsSearched);
+            throw new WeavingException($"Could not find path to weavers file. Searched '{pathsSearchedString}'.");
         }
         return files;
     }
+
+    public static List<string> FindWeaverConfigs(string solutionDirectoryPath, string projectDirectory, ILogger logger) =>
+        FindWeaverConfigs(projectDirectory, logger, new[] { solutionDirectoryPath }, null);
 }

--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -35,7 +35,7 @@
     </Otherwise>
   </Choose>
   <PropertyGroup>
-    <ProjectWeaverXml>$(ProjectDir)FodyWeavers.xml</ProjectWeaverXml>
+    <ProjectWeaverXml Condition="'$(ProjectWeaverXml)' != ''">$(ProjectDir)FodyWeavers.xml</ProjectWeaverXml>
     <FodySignAssembly Condition="$(FodySignAssembly) == '' Or $(FodySignAssembly) == '*Undefined*'">$(SignAssembly)</FodySignAssembly>
     <FodyPath Condition="$(FodyPath) == '' Or $(FodyPath) == '*Undefined*'">$(MSBuildThisFileDirectory)..\</FodyPath>
   </PropertyGroup>
@@ -84,6 +84,7 @@
           DebugType="$(DebugType)"
           DocumentationFilePath="@(DocFileItem->'%(FullPath)')"
           MsBuildThisFileDirectory="$(MSBuildThisFileDirectory)"
+          ProjectWeaverXml="$(ProjectWeaverXml)"
       >
 
       <Output

--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -16,6 +16,7 @@ public partial class Processor
     public string SolutionDirectory;
     public string NuGetPackageRoot;
     public string MSBuildDirectory;
+    public string ProjectWeaverXmlPath;
     public bool DebugSymbols;
     public List<string> ReferenceCopyLocalPaths;
     public List<string> PackageDefinitions;
@@ -40,7 +41,7 @@ public partial class Processor
 
     public virtual bool Execute()
     {
-        Logger.LogInfo($"Fody (version {typeof (Processor).Assembly.GetName().Version}) Executing");
+        Logger.LogInfo($"Fody (version {typeof(Processor).Assembly.GetName().Version}) Executing");
 
         var stopwatch = Stopwatch.StartNew();
 
@@ -66,7 +67,8 @@ public partial class Processor
 
         ValidateAssemblyPath();
 
-        ConfigFiles = ConfigFileFinder.FindWeaverConfigs(SolutionDirectory, ProjectDirectory, Logger);
+        //ConfigFiles = ConfigFileFinder.FindWeaverConfigs(SolutionDirectory, ProjectDirectory, Logger);
+        ConfigFiles = ConfigFileFinder.FindWeaverConfigs(ProjectDirectory, Logger, new[] { SolutionDirectory }, new[] { ProjectWeaverXmlPath });
 
         if (!ShouldStartSinceFileChanged())
         {

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -50,7 +50,7 @@ namespace Fody
         //TODO move back to DebugSymbols when it resolves to true in release mode
         public bool DebugSymbols { get; set; }
         public string DebugType { get; set; }
-
+        public string ProjectWeaverXml { get; set; }
         public override bool Execute()
         {
             var referenceCopyLocalPaths = ReferenceCopyLocalPaths.Select(x => x.ItemSpec).ToList();
@@ -74,7 +74,8 @@ namespace Fody
                 NuGetPackageRoot = NuGetPackageRoot,
                 MSBuildDirectory = MSBuildThisFileDirectory,
                 PackageDefinitions = PackageDefinitions?.ToList(),
-                DebugSymbols = DebugSymbolsProduced()
+                DebugSymbols = DebugSymbolsProduced(),
+                ProjectWeaverXmlPath = ProjectWeaverXml
             };
             var success = processor.Execute();
             if (success)


### PR DESCRIPTION
- [ ] Test

Questions:
Separate `$(ProjectWeaverXml)` by ';' if multiple paths defined?
How to handle if relative path defined?