### PR TITLE
Fetching the version info from AssemblyFileVersionAttribute when Assembly.Location is not available

### DIFF
--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -245,29 +245,44 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
         var typeDefinition = new TypeDefinition(null, "ProcessedByFody", typeAttributes, TypeSystem.ObjectReference);
         ModuleDefinition.Types.Add(typeDefinition);
 
-        AddVersionField(typeof(IInnerWeaver).Assembly.Location, "FodyVersion", typeDefinition);
+        AddVersionField(typeof(IInnerWeaver).Assembly, "FodyVersion", typeDefinition);
 
         foreach (var weaver in weaverInstances)
         {
-            var configAssemblyPath = weaver.Config.AssemblyPath;
+            var configAssembly = weaver.Instance.GetType().Assembly;
             var name = weaver.Config.AssemblyName.Replace(".", string.Empty);
-            AddVersionField(configAssemblyPath, name, typeDefinition);
+            AddVersionField(configAssembly, name, typeDefinition);
         }
 
         var finishedMessage = $"  Finished in {startNew.ElapsedMilliseconds}ms {Environment.NewLine}";
         Logger.LogDebug(finishedMessage);
     }
 
-    void AddVersionField(string configAssemblyPath, string name, TypeDefinition typeDefinition)
+    void AddVersionField(Assembly assembly, string name, TypeDefinition typeDefinition)
     {
-        var weaverVersion = FileVersionInfo.GetVersionInfo(configAssemblyPath);
+        var weaverVersion = "0.0.0.0";
+        if (!string.IsNullOrEmpty(assembly.Location))
+        {
+            var fileName = Path.GetFullPath(assembly.Location);
+            weaverVersion = FileVersionInfo.GetVersionInfo(fileName).FileVersion;
+        }
+        else
+        {
+            var attrs = assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute));
+            var fileVersionAttribute = (AssemblyFileVersionAttribute)attrs.FirstOrDefault();
+            if (fileVersionAttribute != null)
+            {
+                weaverVersion = fileVersionAttribute.Version;
+            }
+        }
+        
         var fieldAttributes = FieldAttributes.Assembly |
                               FieldAttributes.Literal |
                               FieldAttributes.Static |
                               FieldAttributes.HasDefault;
         var field = new FieldDefinition(name, fieldAttributes, TypeSystem.StringReference)
         {
-            Constant = weaverVersion.FileVersion
+            Constant = weaverVersion
         };
 
         typeDefinition.Fields.Add(field);

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -261,12 +261,7 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
     void AddVersionField(Assembly assembly, string name, TypeDefinition typeDefinition)
     {
         var weaverVersion = "0.0.0.0";
-        if (!string.IsNullOrEmpty(assembly.Location))
-        {
-            var fileName = Path.GetFullPath(assembly.Location);
-            weaverVersion = FileVersionInfo.GetVersionInfo(fileName).FileVersion;
-        }
-        else
+        if (string.IsNullOrEmpty(assembly.Location))
         {
             var attrs = assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute));
             var fileVersionAttribute = (AssemblyFileVersionAttribute)attrs.FirstOrDefault();
@@ -274,6 +269,11 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
             {
                 weaverVersion = fileVersionAttribute.Version;
             }
+        }
+        else
+        {
+            var fileName = Path.GetFullPath(assembly.Location);
+            weaverVersion = FileVersionInfo.GetVersionInfo(fileName).FileVersion;
         }
         
         var fieldAttributes = FieldAttributes.Assembly |

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -261,19 +261,11 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
     void AddVersionField(Assembly assembly, string name, TypeDefinition typeDefinition)
     {
         var weaverVersion = "0.0.0.0";
-        if (string.IsNullOrEmpty(assembly.Location))
+        var attrs = assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute));
+        var fileVersionAttribute = (AssemblyFileVersionAttribute)attrs.FirstOrDefault();
+        if (fileVersionAttribute != null)
         {
-            var attrs = assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute));
-            var fileVersionAttribute = (AssemblyFileVersionAttribute)attrs.FirstOrDefault();
-            if (fileVersionAttribute != null)
-            {
-                weaverVersion = fileVersionAttribute.Version;
-            }
-        }
-        else
-        {
-            var fileName = Path.GetFullPath(assembly.Location);
-            weaverVersion = FileVersionInfo.GetVersionInfo(fileName).FileVersion;
+            weaverVersion = fileVersionAttribute.Version;
         }
         
         var fieldAttributes = FieldAttributes.Assembly |

--- a/Tests/FodyIsolated/AssemblyVersionTests.cs
+++ b/Tests/FodyIsolated/AssemblyVersionTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+public class AssemblyVersionTests : TestBase
+{
+    [Fact]
+    void ShouldReadTheSameFodyCommonVersionInfoFromAssemblyAttributeAndFile()
+    {
+        var asm = Assembly.Load("FodyCommon");
+        var attrs = asm.GetCustomAttributes(typeof(AssemblyFileVersionAttribute));
+        var asmFileVersionAttribute = (AssemblyFileVersionAttribute)attrs.FirstOrDefault();
+
+        Assert.NotNull(asmFileVersionAttribute);
+
+        var fileVersion = FileVersionInfo.GetVersionInfo(Path.GetFullPath(asm.Location));
+
+        Assert.Equal(fileVersion.FileVersion, asmFileVersionAttribute.Version);
+    }
+}


### PR DESCRIPTION
As discussed [here](https://github.com/Fody/Fody/issues/556), I've implemented a fix and added a unit test to ensure there are no breaking changes.

The fix should not affect anyone who had things working for them so far. It only addresses rare and specific scenario where assembly version could not be retrieved from file, because there is no file (i.e. the assembly is embedded in another or otherwise dynamically resolved).

Feel free to comment on the implementation!