### PR TITLE
Add NCrunch support to weavers by default

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -73,9 +73,10 @@
       />
   </Target>
 
-  <!--Support for ncrunch-->
+  <!-- Support for NCrunch -->
   <ItemGroup  Condition="'$(NCrunch)' == '1'">
     <None Include="$(FodyAssemblyFile)\*.*" />
+    <None Include="@(WeaverFiles)" />
   </ItemGroup>
 
 </Project>

--- a/FodyPackaging/Weaver.Props.Template
+++ b/FodyPackaging/Weaver.Props.Template
@@ -1,12 +1,17 @@
 ﻿<Project>
+
   <PropertyGroup>
-    <RuntimeToken Condition="$(MSBuildRuntimeType) == 'Core'">netclassicweaver</RuntimeToken>
-    <RuntimeToken Condition="$(MSBuildRuntimeType) != 'Core'">netstandardweaver</RuntimeToken>
+    <WeaverRuntimeToken Condition="$(MSBuildRuntimeType) != 'Core'">netclassicweaver</WeaverRuntimeToken>
+    <WeaverRuntimeToken Condition="$(MSBuildRuntimeType) == 'Core'">netstandardweaver</WeaverRuntimeToken>
   </PropertyGroup>
+
   <ItemGroup>
-    <FilesToAdd Include="$(MsBuildThisFileDirectory)..\$(RuntimeToken)\$(MSBuildThisFileName).dll" />
+    <WeaverFiles Include="$(MsBuildThisFileDirectory)..\$(WeaverRuntimeToken)\$(MSBuildThisFileName).dll" />
   </ItemGroup>
-  <ItemGroup>
-    <WeaverFiles Include="@(FilesToAdd)"/>
+
+  <!-- Support for NCrunch -->
+  <ItemGroup  Condition="'$(NCrunch)' == '1'">
+    <None Include="@(WeaverFiles)" />
   </ItemGroup>
+
 </Project>

--- a/FodyPackaging/Weaver.Props.Template
+++ b/FodyPackaging/Weaver.Props.Template
@@ -1,4 +1,4 @@
-﻿<Project>
+﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <WeaverRuntimeToken Condition="$(MSBuildRuntimeType) != 'Core'">netclassicweaver</WeaverRuntimeToken>
@@ -7,11 +7,6 @@
 
   <ItemGroup>
     <WeaverFiles Include="$(MsBuildThisFileDirectory)..\$(WeaverRuntimeToken)\$(MSBuildThisFileName).dll" />
-  </ItemGroup>
-
-  <!-- Support for NCrunch -->
-  <ItemGroup  Condition="'$(NCrunch)' == '1'">
-    <None Include="@(WeaverFiles)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This makes the addins play nicely with NCrunch by default.

I also inverted netclassicweaver/netstandardweaver because I noticed my "fulll .NET" MSBuild was using the netstandardweaver version.

I renamed  `RuntimeToken` to `WeaverRuntimeToken` to make it more specific to Fody, just in case.

Finally, I couldn't reproduce any issues by eliminating the `FilesToAdd` intermediate item, so I removed the indirection.
