### PR TITLE
Fix #563

### DIFF
--- a/Fody/SolutionDirectoryFinder.cs
+++ b/Fody/SolutionDirectoryFinder.cs
@@ -1,15 +1,15 @@
 using System.IO;
 
-class SolutionDirectoryFinder
+public class SolutionDirectoryFinder
 {
     public static string Find(string solutionDir, string nCrunchOriginalSolutionDir, string projectDirectory)
     {
-        if (nCrunchOriginalSolutionDir != null)
+        if (!string.IsNullOrEmpty(nCrunchOriginalSolutionDir))
         {
             return nCrunchOriginalSolutionDir;
         }
 
-        if (solutionDir != null)
+        if (!string.IsNullOrEmpty(solutionDir) && solutionDir != "*Undefined*")
         {
             return solutionDir;
         }

--- a/Tests/Fody/SolutionDirectoryFinderTests.cs
+++ b/Tests/Fody/SolutionDirectoryFinderTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+public class SolutionDirectoryFinderTests : TestBase
+{
+    [Fact]
+    public void ReturnNCrunchSolutionWhenPresent()
+    {
+        var result = SolutionDirectoryFinder.Find("Foo", "Baz", "Bar");
+        Assert.Equal("Baz", result);
+    }
+
+    [Fact]
+    public void ReturnSolutionWhenPresent()
+    {
+        var result = SolutionDirectoryFinder.Find("Foo", null, "Bar");
+        Assert.Equal("Foo", result);
+    }
+
+    [Fact]
+    public void ReturnProjectParentWhenSolutionIsEmpty()
+    {
+        var result = SolutionDirectoryFinder.Find(null, null, Environment.CurrentDirectory);
+        Assert.Equal(Path.GetDirectoryName(Environment.CurrentDirectory), result);
+    }
+
+    [Fact]
+    public void IgnoreUndefinedSolution()
+    {
+        var result = SolutionDirectoryFinder.Find("*Undefined*", null, Environment.CurrentDirectory);
+        Assert.Equal(Path.GetDirectoryName(Environment.CurrentDirectory), result);
+    }
+}


### PR DESCRIPTION
This fixes #563. A bug was introduced in 53bb679af6 by removing support for the `*Undefined*` value that `$(SolutionDir)` gets when a single project is compiled without a solution.