### PR TITLE
Prevent weaver lib from being copied to build output when not referenced

### DIFF
--- a/Fody.sln
+++ b/Fody.sln
@@ -30,8 +30,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoSync", "RepoSync\RepoSync.csproj", "{8C9C3B12-7F35-4E63-A230-E05F2F306A3D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleWeaver", "SampleWeaver\SampleWeaver.csproj", "{C07F5786-84DD-460C-A846-50311562790D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{2C10CBD1-5913-46D5-B705-0F3B46E68DD1} = {2C10CBD1-5913-46D5-B705-0F3B46E68DD1}
+	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleTarget", "SampleTarget\SampleTarget.csproj", "{B4A955E6-0DC2-47C3-9F08-CA44823AA70F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleTarget", "SampleTarget\SampleTarget.csproj", "{B4A955E6-0DC2-47C3-9F08-CA44823AA70F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/FodyHelpers/ReferenceCleaner.cs
+++ b/FodyHelpers/ReferenceCleaner.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Fody;
 using Mono.Cecil;
@@ -12,15 +14,22 @@ static class ReferenceCleaner
             return;
         }
 
-        var weaverName = weaver.GetType().Assembly.GetName().Name.ReplaceCaseless(".Fody", "");
-        var referenceToRemove = module.AssemblyReferences
-            .FirstOrDefault(x => x.Name == weaverName);
-        if (referenceToRemove == null)
+        var weaverLibName = weaver.GetType().Assembly.GetName().Name.ReplaceCaseless(".Fody", "");
+        log($"\tRemoving reference to '{weaverLibName}'.");
+
+        var referenceToRemove = module.AssemblyReferences.FirstOrDefault(x => x.Name == weaverLibName);
+        if (referenceToRemove != null)
         {
-            return;
+            module.AssemblyReferences.Remove(referenceToRemove);
         }
 
-        module.AssemblyReferences.Remove(referenceToRemove);
-        log($"\tRemoving reference to '{weaverName}'.");
+        var copyLocalFilesToRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            weaverLibName + ".dll",
+            weaverLibName + ".xml",
+            weaverLibName + ".pdb"
+        };
+
+        weaver.ReferenceCopyLocalPaths.RemoveAll(refPath => copyLocalFilesToRemove.Contains(Path.GetFileName(refPath)));
     }
 }

--- a/FodyHelpers/ReferenceCleaner.cs
+++ b/FodyHelpers/ReferenceCleaner.cs
@@ -27,7 +27,8 @@ static class ReferenceCleaner
         {
             weaverLibName + ".dll",
             weaverLibName + ".xml",
-            weaverLibName + ".pdb"
+            weaverLibName + ".pdb",
+            weaverLibName + ".mdb" // TODO: Remove this when mdb becomes redundant
         };
 
         weaver.ReferenceCopyLocalPaths.RemoveAll(refPath => copyLocalFilesToRemove.Contains(Path.GetFileName(refPath)));

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -215,12 +215,8 @@ public partial class InnerWeaver : MarshalByRefObject, IInnerWeaver
                 }
                 var finishedMessage = $"  Finished '{weaver.Config.AssemblyName}' in {startNew.ElapsedMilliseconds}ms {Environment.NewLine}";
                 Logger.LogDebug(finishedMessage);
-#pragma warning disable 618
-                if (weaver.Instance is BaseModuleWeaver baseModuleWeaver)
-                {
-                    ReferenceCleaner.CleanReferences(ModuleDefinition, baseModuleWeaver, Logger.LogDebug);
-                }
-#pragma warning restore 618
+
+                ReferenceCleaner.CleanReferences(ModuleDefinition, weaver.Instance, Logger.LogDebug);
             }
             finally
             {

--- a/Integration/WithNugetWeavers/WithNugetWeavers.csproj
+++ b/Integration/WithNugetWeavers/WithNugetWeavers.csproj
@@ -2,8 +2,14 @@
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Fody" Version="$(IntegrationVersion)" />
     <PackageReference Include="Virtuosity.Fody" Version="1.21.1" />
   </ItemGroup>
+
+  <Target Name="VerifyThereAreNoWeaversInOutput" AfterTargets="AfterBuild">
+    <Error Condition="Exists('$(OutDir)Virtuosity.dll')"
+           Text="Virtuosity.dll found in build output" />
+  </Target>
 </Project>

--- a/SampleWeaver.Fody/ModuleWeaver.cs
+++ b/SampleWeaver.Fody/ModuleWeaver.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-
 using Fody;
 
 public class ModuleWeaver : BaseModuleWeaver
@@ -27,8 +26,14 @@ public class ModuleWeaver : BaseModuleWeaver
             ReferenceCopyLocalPaths.Remove(filePath);
             ReferenceCopyLocalPaths.Remove(Path.ChangeExtension(filePath, ".pdb"));
             ReferenceCopyLocalPaths.Remove(Path.ChangeExtension(filePath, ".xml"));
-        }
 
+            // Do not use ShouldCleanReference in order to test the above code
+            var assemblyRef = ModuleDefinition.AssemblyReferences.FirstOrDefault(i => i.Name == "SampleWeaver");
+            if (assemblyRef != null)
+            {
+                ModuleDefinition.AssemblyReferences.Remove(assemblyRef);
+            }
+        }
     }
 
     public override IEnumerable<string> GetAssembliesForScanning()
@@ -36,5 +41,5 @@ public class ModuleWeaver : BaseModuleWeaver
         yield break;
     }
 
-    public override bool ShouldCleanReference => true;
+    public override bool ShouldCleanReference => false;
 }

--- a/Tests/FodyHelpers/WeaverTestHelperTests.Run.approved.txt
+++ b/Tests/FodyHelpers/WeaverTestHelperTests.Run.approved.txt
@@ -1,6 +1,11 @@
 ﻿{
   "Errors": [],
-  "Messages": [],
+  "Messages": [
+    {
+      "Text": "\tRemoving reference to 'Tests'.",
+      "MessageImportance": "Normal"
+    }
+  ],
   "Warnings": [],
   "AssemblyPath": "\fodytemp\DummyAssembly.dll",
   "FullName": "DummyAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"

--- a/Tests/FodyHelpers/WeaverTestHelperTests.WeaverUsingSymbols.approved.txt
+++ b/Tests/FodyHelpers/WeaverTestHelperTests.WeaverUsingSymbols.approved.txt
@@ -1,6 +1,11 @@
 ﻿{
   "Errors": [],
-  "Messages": [],
+  "Messages": [
+    {
+      "Text": "\tRemoving reference to 'Tests'.",
+      "MessageImportance": "Normal"
+    }
+  ],
   "Warnings": [],
   "AssemblyPath": "\fodytemp\DummyAssembly.dll",
   "FullName": "DummyAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"

--- a/Tests/FodyHelpers/WeaverTestHelperTests.WithCustomAssemblyName.approved.txt
+++ b/Tests/FodyHelpers/WeaverTestHelperTests.WithCustomAssemblyName.approved.txt
@@ -1,6 +1,11 @@
 ﻿{
   "Errors": [],
-  "Messages": [],
+  "Messages": [
+    {
+      "Text": "\tRemoving reference to 'Tests'.",
+      "MessageImportance": "Normal"
+    }
+  ],
   "Warnings": [],
   "AssemblyPath": "\fodytemp\NewName.dll",
   "FullName": "NewName, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"


### PR DESCRIPTION
Thanks to #568 we can now easily prevent the weaver libraries from being copied to the output directory when the reference to the weaver is cleaned. This PR does just that.

Note that the "integration test" for this change is in `WithNugetWeavers.csproj` - I couldn't think of a better way to test this.
