### PR TITLE
Fix #580: use source link to enrich pdbs with github information

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,9 +33,6 @@
 
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <DebugType>embedded</DebugType>
-    <Deterministic>true</Deterministic>
-    <DeterministicSourcePaths>true</DeterministicSourcePaths>
   </PropertyGroup>
   
   <!-- Global settings to run integration tests inline while building -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,8 +28,15 @@
   <!-- Boost the debugging experience when building weavers -->
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <DebugType>embedded</DebugType>
+    <Deterministic>true</Deterministic>
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+  </PropertyGroup>
   
   <!-- Global settings to run integration tests inline while building -->
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,10 +25,16 @@
     </ItemGroup>
   </Target>
 
+  <!-- Boost the debugging experience when building weavers -->
+
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
+  </ItemGroup>
+  
   <!-- Global settings to run integration tests inline while building -->
 
   <PropertyGroup>
-    <IsInlineIntegrationTestActive Condition="'$(MSBUILDDISABLENODERESUSE)'=='1'" >true</IsInlineIntegrationTestActive>
+    <IsInlineIntegrationTestActive Condition="'$(MSBUILDDISABLENODERESUSE)'=='1' AND '$(MSBuildNodeCount)'=='1'">true</IsInlineIntegrationTestActive>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,10 +32,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
-    <DebugType>embedded</DebugType>	
-    <Deterministic>true</Deterministic>	
-    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   
   <!-- Global settings to run integration tests inline while building -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,10 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
+    <DebugType>embedded</DebugType>	
+    <Deterministic>true</Deterministic>	
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
   </PropertyGroup>
   
   <!-- Global settings to run integration tests inline while building -->


### PR DESCRIPTION
Fix #580: use microsoft source link to enrich pdbs with github information
replaces #581