### PR TITLE
Do not require a solution for FodyPackaging to work

### DIFF
--- a/FodyPackaging/build/FodyPackaging.props
+++ b/FodyPackaging/build/FodyPackaging.props
@@ -3,7 +3,10 @@
     <PackageId Condition="'$(PackageId)' == ''">$(MSBuildProjectName).Fody</PackageId>
     <PackageRequireLicenseAcceptance Condition="'$(PackageRequireLicenseAcceptance)' == ''">false</PackageRequireLicenseAcceptance>
     <PackageTags Condition="'$(PackageTags)' == ''">ILWeaving, Fody, Cecil, AOP</PackageTags>
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(SolutionDir)nugets</PackageOutputPath>
+    <FodySolutionDir Condition="'$(SolutionDir)' != '*Undefined*'">$(SolutionDir)</FodySolutionDir>
+    <FodySolutionDir Condition="'$(FodySolutionDir)' == ''">$(MSBuildProjectDirectory)</FodySolutionDir>
+    <FodySolutionDir Condition="!HasTrailingSlash('$(FodySolutionDir)')">$(FodySolutionDir)\</FodySolutionDir>
+    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(FodySolutionDir)nugets</PackageOutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeFodyFiles</TargetsForTfmSpecificContentInPackage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -13,8 +16,9 @@
     <WeaverDirPath Condition="'$(WeaverDirPath)' == ''">..\$(PackageId)\bin\$(Configuration)\</WeaverDirPath>
     <WeaverPropsTemplate Condition="'$(WeaverPropsTemplate)' == ''">$(MSBuildThisFileDirectory)..\Weaver.Props.Template</WeaverPropsTemplate>
     <GitHubOrganization Condition="'$(GitHubOrganization)' == ''">Fody</GitHubOrganization>
-    <LocalGitRootFolder Condition="'$(LocalGitRootFolder)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), .git\index))</LocalGitRootFolder>
-    <LocalGitRootFolder Condition="'$(LocalGitRootFolder)' == ''">$(SolutionDir)</LocalGitRootFolder>
+    <LocalGitRootFolder Condition="'$(LocalGitRootFolder)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', '.git\index'))</LocalGitRootFolder>
+    <LocalGitRootFolder Condition="'$(LocalGitRootFolder)' == ''">$(FodySolutionDir)</LocalGitRootFolder>
+    <LocalGitRootFolder Condition="!HasTrailingSlash('$(LocalGitRootFolder)')">$(LocalGitRootFolder)\</LocalGitRootFolder>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FodyPackaging misbehaves when `$(SolutionDir)` is not set (for instance when building a single project), because an empty path is passed to `[MSBuild]::GetDirectoryNameOfFileAbove`, which throws the following error:

> error MSB4184: The expression "[MSBuild]::GetDirectoryNameOfFileAbove('', .git\index)" cannot be evaluated. The path is not of a legal form. 

This PR fixes that by using `$(MSBuildProjectDirectory)` as a starting point instead.

I also noticed that `$(LocalGitRootFolder)` should have a trailing slash, so this change ensures that as well.
