### PR TITLE
Fix #616

### DIFF
--- a/FodyHelpers/build/FodyHelpers.props
+++ b/FodyHelpers/build/FodyHelpers.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <DebugType>embedded</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/FodyIsolated/AssemblyLoader.cs
+++ b/FodyIsolated/AssemblyLoader.cs
@@ -21,9 +21,22 @@ public partial class InnerWeaver
         return assemblies[assemblyPath] = loadFromFile;
     }
 
-    public static Assembly LoadFromFile(string assemblyPath)
+    static Assembly LoadFromFile(string assemblyPath)
     {
         var rawAssembly = File.ReadAllBytes(assemblyPath);
+
+        var pdbPath = Path.ChangeExtension(assemblyPath, "pdb");
+        if (File.Exists(pdbPath))
+        {
+            return Assembly.Load(rawAssembly, File.ReadAllBytes(pdbPath));
+        }
+        
+        var mdbPath = Path.ChangeExtension(assemblyPath, "mdb");
+        if (File.Exists(mdbPath))
+        {
+            return Assembly.Load(rawAssembly, File.ReadAllBytes(mdbPath));
+        }
+
         return Assembly.Load(rawAssembly);
     }
 }

--- a/FodyPackaging/build/FodyPackaging.targets
+++ b/FodyPackaging/build/FodyPackaging.targets
@@ -11,6 +11,8 @@
     <ItemGroup>
       <NetClassicFilesToInclude Include="$(WeaverDirPath)\net4*\$(PackageId).xcf" />
       <NetStandardFilesToInclude Include="$(WeaverDirPath)\netstandard2*\$(PackageId).xcf" />
+      <NetClassicFilesToInclude Include="$(WeaverDirPath)\net4*\$(PackageId).pdb" />
+      <NetStandardFilesToInclude Include="$(WeaverDirPath)\netstandard2*\$(PackageId).pdb" />
 
       <TfmSpecificPackageFile Include="@(NetClassicFilesToInclude)" PackagePath="netclassicweaver\%(Filename)%(Extension)" />
       <TfmSpecificPackageFile Include="@(NetStandardFilesToInclude)" PackagePath="netstandardweaver\%(Filename)%(Extension)" />


### PR DESCRIPTION
Fix #616 
Revert https://github.com/Fody/Fody/commit/2a75c613d44dd278474cf335dec3780c25dc1b8d
Embedded symbols don't work this way (MS bug)