### PR TITLE
Add support for FodyGenerateXsd MSBuild property

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -8,6 +8,7 @@
     <FodyAssembly Condition="'$(FodyAssembly)' == ''">$(FodyAssemblyDirectory)\Fody.dll</FodyAssembly>
     <FodyCopyLocalFilesCache Condition="'$(FodyCopyLocalFilesCache)' == ''">$(MSBuildProjectFile).Fody.CopyLocal.cache</FodyCopyLocalFilesCache>
     <DefaultItemExcludes>$(DefaultItemExcludes);FodyWeavers.xsd</DefaultItemExcludes>
+    <FodyGenerateXsd Condition="'$(FodyGenerateXsd)' == ''">true</FodyGenerateXsd>
   </PropertyGroup>
 
   <!-- Support for NCrunch -->
@@ -46,6 +47,7 @@
         WeaverFiles="@(WeaverFiles)"
         NCrunchOriginalSolutionDirectory="$(NCrunchOriginalSolutionDir)"
         IntermediateCopyLocalFilesCache="$(IntermediateOutputPath)$(FodyCopyLocalFilesCache)"
+        GenerateXsd="$(FodyGenerateXsd)"
       >
 
       <Output

--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -21,6 +21,7 @@ public partial class Processor
     public List<string> ReferenceCopyLocalPaths;
     public List<string> DefineConstants;
     public List<string> ConfigFiles;
+    public bool GenerateXsd;
     IInnerWeaver innerWeaver;
 
     AddinFinder addinFinder;
@@ -68,7 +69,7 @@ public partial class Processor
 
         ValidateAssemblyPath();
 
-        ConfigFiles = ConfigFile.FindWeaverConfigs(SolutionDirectory, ProjectDirectory, Logger, WeaverFilesFromProps);
+        ConfigFiles = ConfigFile.FindWeaverConfigs(SolutionDirectory, ProjectDirectory, Logger, WeaverFilesFromProps, GenerateXsd);
 
         if (!ShouldStartSinceFileChanged())
         {
@@ -120,7 +121,7 @@ see https://github.com/Fody/Fody/wiki/SampleUsage");
 
         ConfigureWhenNoWeaversFound();
 
-        ConfigFile.EnsureSchemaIsUpToDate(ProjectDirectory, WeaverFilesFromProps, Weavers);
+        ConfigFile.EnsureSchemaIsUpToDate(ProjectDirectory, WeaverFilesFromProps, Weavers, GenerateXsd);
 
         Logger.LogDebug($"Finished finding weavers {stopwatch.ElapsedMilliseconds}ms");
     }

--- a/Fody/Verify/Verifier.cs
+++ b/Fody/Verify/Verifier.cs
@@ -69,7 +69,7 @@ public class Verifier
 
     public bool ReadShouldVerifyAssembly(out List<string> ignoreCodes)
     {
-        var weaverConfigs = ConfigFile.FindWeaverConfigs(SolutionDirectory, ProjectDirectory, Logger, null);
+        var weaverConfigs = ConfigFile.FindWeaverConfigs(SolutionDirectory, ProjectDirectory, Logger, null, false);
         ignoreCodes = ExtractVerifyIgnoreCodesConfigs(weaverConfigs).ToList();
         if (DefineConstants.Any(x => x == "FodyVerifyAssembly"))
         {

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -52,6 +52,8 @@ namespace Fody
         [Required]
         public string IntermediateCopyLocalFilesCache { get; set; }
 
+        public bool GenerateXsd { get; set; }
+
         public override bool Execute()
         {
             var referenceCopyLocalPaths = ReferenceCopyLocalFiles.Select(x => x.ItemSpec).ToList();
@@ -76,7 +78,8 @@ namespace Fody
                 NuGetPackageRoot = NuGetPackageRoot,
                 MSBuildDirectory = MSBuildThisFileDirectory,
                 WeaverFilesFromProps = GetWeaverFilesFromProps(),
-                DebugSymbols = GetDebugSymbolsType()
+                DebugSymbols = GetDebugSymbolsType(),
+                GenerateXsd = GenerateXsd
             };
             var success = processor.Execute();
 

--- a/Tests/Fody/ProjectWeaversFinderTests.cs
+++ b/Tests/Fody/ProjectWeaversFinderTests.cs
@@ -15,7 +15,7 @@ public class ProjectWeaversFinderTests : TestBase
         var searchDirectory = Path.Combine(AssemblyLocation.CurrentDirectory, "FodyWeavers.xml");
 
         var weavingException = Assert.Throws<WeavingException>(
-            () => ConfigFile.FindWeaverConfigs(AssemblyLocation.CurrentDirectory, AssemblyLocation.CurrentDirectory, logger, null));
+            () => ConfigFile.FindWeaverConfigs(AssemblyLocation.CurrentDirectory, AssemblyLocation.CurrentDirectory, logger, null, false));
         Approvals.Verify(weavingException.Message.Replace(searchDirectory, "SearchDirectory"));
     }
 }


### PR DESCRIPTION
This is an addition to #615. It adds a `FodyGenerateXsd` MSBuild property which you can set to `false` to opt out of XSD generation. You can apply this to a whole solution by setting it in the `Directory.Build.props` file.

This property sets a default: you can still write `GenerateXsd="true"` in `FodyWeavers.xml` to override this setting.
