### PR TITLE
Build failure when no FodyWeavers.xml at project level

### DIFF
--- a/Fody/ConfigFileFinder.cs
+++ b/Fody/ConfigFileFinder.cs
@@ -25,19 +25,22 @@ public static class ConfigFile
         var projectConfigFilePath = Path.Combine(projectDirectory, FodyWeaversConfigFileName);
         if (!File.Exists(projectConfigFilePath))
         {
-            if (!files.Any() && wellKnownWeaverFiles != null)
+            if (!files.Any())
             {
-                GenerateDefault(projectConfigFilePath, wellKnownWeaverFiles, defaultGenerateXsd);
+                if (wellKnownWeaverFiles != null)
+                {
+                    GenerateDefault(projectConfigFilePath, wellKnownWeaverFiles, defaultGenerateXsd);
 
-                logger.LogError($"Could not find a FodyWeavers.xml file at the project level ({projectConfigFilePath}). A default file has been created. Please review the file and add it to your project.");
-            }
-            else
-            {
-                logger.LogError($@"Could not find a FodyWeavers.xml file at the project level ({projectConfigFilePath}). Some project types do not support using NuGet to add content files e.g. netstandard projects. In these cases it is necessary to manually add a FodyWeavers.xml to the project. Example content:
+                    logger.LogError($"Could not find a FodyWeavers.xml file at the project level ({projectConfigFilePath}). A default file has been created. Please review the file and add it to your project.");
+                }
+                else
+                {
+                    logger.LogError($@"Could not find a FodyWeavers.xml file at the project level ({projectConfigFilePath}). Some project types do not support using NuGet to add content files e.g. netstandard projects. In these cases it is necessary to manually add a FodyWeavers.xml to the project. Example content:
   <Weavers>
     <WeaverName/>
   </Weavers>
   ");
+                }
             }
         }
         else


### PR DESCRIPTION
I was updating various build components to their latest versions and when updating Fody encountered a breaking change I believe was made here https://github.com/Fody/Fody/pull/598/files#diff-46dbf35f7a743d6892884d244ffd5d5fR28 which changed a `logger.LogDebug` to `logger.LogError` and seems to be causing builds to fail.

This PR has a fix implementing what I believe is the desired logic: if a config file is found in the solution directory, not finding a config file in the project directory won't log an error and fail a running build.

I did read the guidelines in the PR template but hope this small fix is acceptable. Cheers.