### PR TITLE
fix: Made the Fody.Packaging compatible with the new Nuget license tags in csproj

### DIFF
--- a/FodyPackaging/build/FodyPackaging.props
+++ b/FodyPackaging/build/FodyPackaging.props
@@ -33,14 +33,14 @@
 
   <PropertyGroup Condition="'$(GitHubOrganization)' == 'Fody'">
     <PackageIconUrl Condition="'$(PackageIconUrl)' == ''">https://raw.githubusercontent.com/Fody/$(SolutionName)/master/package_icon.png</PackageIconUrl>
-    <PackageLicenseUrl Condition="'$(PackageLicenseUrl)' == ''">http://www.opensource.org/licenses/mit-license.php</PackageLicenseUrl>
+    <PackageLicenseExpression Condition="'$(PackageLicenseUrl)' == '' AND '$(PackageLicenseExpression)' == '' AND '$(PackageLicenseFile)' == ''">MIT</PackageLicenseExpression>
     <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">http://github.com/Fody/$(SolutionName)</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GitHubOrganization)' != 'Fody'">
     <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">http://github.com/$(GitHubOrganization)/$(PackageId)</PackageProjectUrl>
     <PackageIconUrl Condition="'$(PackageIconUrl)' == '' And '$(PackageIconFileName)' != ''">https://raw.githubusercontent.com/$(GitHubOrganization)/$(PackageId)/master/$(PackageIconFileName)</PackageIconUrl>
-    <PackageLicenseUrl Condition="'$(PackageLicenseUrl)' == '' And '$(PackageLicenseFileName)' != ''">https://raw.githubusercontent.com/$(GitHubOrganization)/$(PackageId)/master/$(PackageLicenseFileName)</PackageLicenseUrl>
+    <PackageLicenseFile Condition="'$(PackageLicenseExpression)' == '' AND '$(PackageLicenseFile)' == '' AND '$(PackageLicenseUrl)' == '' AND '$(PackageLicenseFileName)' != ''">$(PackageLicenseFileName)</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Description

In ReactiveUI.Fody we are using the new recommended way of using **PackageLicenseExpression** (or **PackageLicenseFile** but we opted into using the Expression).

[FodyPackaging.props](https://github.com/Fody/Fody/blob/e924e1f361ab36fd37b5dff77561965285f05eae/FodyPackaging/build/FodyPackaging.props#L43) is setting a _PackageLicenseUrl_ if none is found and this is producing the following error:
```
error NU5035: The PackageLicenseUrl is being deprecated and cannot be used in conjunction with the PackageLicenseFile or PackageLicenseExpression.
```
#### The solution

1. For the case of a Fody based package, unless there is a PackageLicenseExpression, PackageLicenseUrl or PackageLicenseFile set, set the PackageLicenseExpression to MIT
2. In the case of externally hosted URL add additional checks for the PackageLicenseExpression and PackageLicenseFile before setting the PackageLicenseFile. This will be set the PackageLicenseFileName tag.

#### Todos

 * [x ] Related issues
Fixes #638
 * [x ] Tests
 -- Tested with local Reactiveui.fody project.
 * [ ] Documentation
Documentation 