### PR TITLE
Register the references cache file

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -54,6 +54,10 @@
 
     </Fody.WeavingTask>
 
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateOutputPath)$(FodyCopyLocalFilesCache)" />
+    </ItemGroup>
+
   </Target>
 
   <Target


### PR DESCRIPTION
Minor cleanup: This causes the cache file to be deleted when the Clean target is called.
