### PR TITLE
Make the CoreCompile target depend on FodyWeavers.xml

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -11,8 +11,9 @@
     <FodyGenerateXsd Condition="'$(FodyGenerateXsd)' == ''">true</FodyGenerateXsd>
   </PropertyGroup>
 
-  <ItemGroup>
-    <UpToDateCheckInput Include="$(ProjectWeaverXml)" Condition="Exists('$(ProjectWeaverXml)')" />
+  <ItemGroup Condition="Exists('$(ProjectWeaverXml)')">
+    <UpToDateCheckInput Include="$(ProjectWeaverXml)" />
+    <CustomAdditionalCompileInputs Include="$(ProjectWeaverXml)" />
   </ItemGroup>
 
   <!-- Support for NCrunch -->


### PR DESCRIPTION
@SimonCropp Sorry but I wasn't clear in #651 and I think you misunderstood what the change does.

That change ensured that MSBuild would be called if FodyWeavers.xml is changed, but this doesn't mean that the CoreCompile target would run, which means that FodyTarget could be called on an already weaved assembly.

This PR fixes that by adding FodyWeavers.xml to the list of dependencies of CoreCompile.

(I thought about doing what you did in #652 and including this change but only after you merged #651)