### PR TITLE
Simplify FodyPackaging

### DIFF
--- a/FodyPackaging/build/FodyPackaging.props
+++ b/FodyPackaging/build/FodyPackaging.props
@@ -2,10 +2,6 @@
   <PropertyGroup>
     <PackageId Condition="'$(PackageId)' == ''">$(MSBuildProjectName).Fody</PackageId>
     <PackageTags Condition="'$(PackageTags)' == ''">ILWeaving, Fody, Cecil, AOP</PackageTags>
-    <FodySolutionDir Condition="'$(FodySolutionDir)' == '' AND '$(SolutionDir)' != '*Undefined*'">$(SolutionDir)</FodySolutionDir>
-    <FodySolutionDir Condition="'$(FodySolutionDir)' == ''">$(MSBuildProjectDirectory)</FodySolutionDir>
-    <FodySolutionDir Condition="!HasTrailingSlash('$(FodySolutionDir)')">$(FodySolutionDir)\</FodySolutionDir>
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(FodySolutionDir)nugets</PackageOutputPath>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetsForTfmSpecificContentInPackage Condition="'$(SkipPackagingDefaultFiles)' != 'true'">$(TargetsForTfmSpecificContentInPackage);IncludeFodyFiles</TargetsForTfmSpecificContentInPackage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -14,39 +10,11 @@
     <DisableFody>true</DisableFody>
     <WeaverDirPath Condition="'$(WeaverDirPath)' == ''">..\$(PackageId)\bin\$(Configuration)\</WeaverDirPath>
     <WeaverPropsFile Condition="'$(WeaverPropsFile)' == ''">$(MSBuildThisFileDirectory)..\Weaver.props</WeaverPropsFile>
-    <GitHubOrganization Condition="'$(GitHubOrganization)' == ''">Fody</GitHubOrganization>
-    <LocalGitRootFolder Condition="'$(LocalGitRootFolder)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', '.git\index'))</LocalGitRootFolder>
-    <LocalGitRootFolder Condition="'$(LocalGitRootFolder)' == ''">$(FodySolutionDir)</LocalGitRootFolder>
-    <LocalGitRootFolder Condition="!HasTrailingSlash('$(LocalGitRootFolder)')">$(LocalGitRootFolder)\</LocalGitRootFolder>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageIconFile Include="$(LocalGitRootFolder)*icon*.png" />
-    <PackageLicenseFile Include="$(LocalGitRootFolder)*license*" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <PackageIconFileName Condition="'$(PackageIconFileName)' == ''">@(PackageIconFile->'%(Filename)%(Extension)')</PackageIconFileName>
-    <PackageLicenseFileName Condition="'$(PackageLicenseFileName)' == ''">@(PackageLicenseFile->'%(Filename)%(Extension)')</PackageLicenseFileName>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(GitHubOrganization)' == 'Fody'">
-    <PackageIconUrl Condition="'$(PackageIconUrl)' == ''">https://raw.githubusercontent.com/Fody/$(SolutionName)/master/package_icon.png</PackageIconUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">http://github.com/Fody/$(SolutionName)</PackageProjectUrl>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(GitHubOrganization)' != 'Fody'">
-    <PackageProjectUrl Condition="'$(PackageProjectUrl)' == ''">http://github.com/$(GitHubOrganization)/$(PackageId)</PackageProjectUrl>
-    <PackageIconUrl Condition="'$(PackageIconUrl)' == '' And '$(PackageIconFileName)' != ''">https://raw.githubusercontent.com/$(GitHubOrganization)/$(PackageId)/master/$(PackageIconFileName)</PackageIconUrl>
-    <PackageLicenseFile Condition="'$(PackageLicenseExpression)' == '' AND '$(PackageLicenseFile)' == '' AND '$(PackageLicenseUrl)' == '' AND '$(PackageLicenseFileName)' != ''">$(PackageLicenseFileName)</PackageLicenseFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- fake reference to the weaver project to work around this bug https://github.com/Microsoft/msbuild/issues/2661 -->
     <ProjectReference Include="..\$(PackageId)\$(PackageId).csproj"
                       PrivateAssets="All"
                       Condition="$(TargetFramework)=='fake'" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This is a breaking change to FodyPackaging.

Some history: FodyPackaging was originally created to only build packages from within the Fody Org. As such many things were hard coded (or specified with a rigid convention) eg license, icon, output dir, project url. FodyPackaging was then made more flexible so it could target projects outside the Fody Org. This was a good change, but had some side effects

 * to achieve this significant complexity had to be added to make the above conventions  overridable or tweaked. 
 * pulled in the assumption/convention that all fody addins are hosted on github.
 * complexity and fragility around determining the output path

Moving forward i believe this will be difficult to document and to maintain

This PR remove those conventions that are complex or overly presumptuous.

All downstream weavers that consume FodyPackaging would need to set their own

 * PackageOutputPath 
 * PackageLicenseExpression
 * PackageProjectUrl 
 * PackageIconFile 
