### PR TITLE
Allow ProjectWeaverXml to be set externally

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <ProjectWeaverXml>$(ProjectDir)FodyWeavers.xml</ProjectWeaverXml>
+    <ProjectWeaverXml Condition="'$(ProjectWeaverXml)' == ''">$(ProjectDir)FodyWeavers.xml</ProjectWeaverXml>
     <FodyPath Condition="$(FodyPath) == '' Or $(FodyPath) == '*Undefined*'">$(MSBuildThisFileDirectory)..\</FodyPath>
     <FodyAssemblyDirectory Condition="'$(MSBuildRuntimeType)' == 'Core'">$(FodyPath)netstandardtask</FodyAssemblyDirectory>
     <FodyAssemblyDirectory Condition="'$(MSBuildRuntimeType)' != 'Core'">$(FodyPath)netclassictask</FodyAssemblyDirectory>


### PR DESCRIPTION
#### Description

Allows ProjectWeaverXml to be set externally

#### The solution

Only set ProjectWeaverXml when it hasn't been set already
Allows doing something like:

```
<ProjectWeaverXml Condition="'$(Configuration)' == 'Release'">$(ProjectDir)FodyWeavers.xml</ProjectWeaverXml>
<ProjectWeaverXml Condition="'$(Configuration)' == 'Debug'">$(ProjectDir)FodyWeavers.xml</ProjectWeaverXml>
```

#### Todos

 * [ ] Related issues
 * [ ] Tests
 * [ ] Documentation