### PR TITLE
Solution-wide config support for `EnsureSchemaIsUpToDate`

### DIFF
--- a/Fody/ConfigFileFinder/ConfigFileFinder.cs
+++ b/Fody/ConfigFileFinder/ConfigFileFinder.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Fody;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
-using Fody;
 
 public static class ConfigFileFinder
 {
@@ -166,16 +166,12 @@ public static class ConfigFileFinder
     {
         var projectConfigFilePath = Path.Combine(projectDirectory, FodyWeaversConfigFileName);
         var solutionConfigFilePath = Path.Combine(solutionDirectory, FodyWeaversConfigFileName);
-        if (File.Exists(projectConfigFilePath))
-            EnsureSchemaIsUpToDate(projectConfigFilePath, XDocumentEx.Load(projectConfigFilePath), weavers, defaultGenerateXsd);
-        if (File.Exists(solutionConfigFilePath))
-            EnsureSchemaIsUpToDate(solutionConfigFilePath, XDocumentEx.Load(solutionConfigFilePath), weavers, defaultGenerateXsd);
-    }
-
-    private static void EnsureSchemaIsUpToDate(string filePath, XDocument doc, IEnumerable<WeaverEntry> weavers, bool defaultGenerateXsd) 
-    {
         try
         {
+            if (!File.Exists(projectConfigFilePath) && File.Exists(solutionConfigFilePath))
+                return;
+
+            var doc = XDocumentEx.Load(projectConfigFilePath);
             if (!ShouldGenerateXsd(doc, defaultGenerateXsd))
             {
                 return;
@@ -189,14 +185,14 @@ public static class ConfigFileFinder
             if (!hasNamespace)
             {
                 doc.Root.Add(SchemaInstanceAttributes);
-                doc.Save(filePath);
+                doc.Save(projectConfigFilePath);
             }
 
-            CreateSchemaForConfig(filePath, weavers);
+            CreateSchemaForConfig(projectConfigFilePath, weavers);
         }
         catch (Exception exception)
         {
-            throw new WeavingException($"Failed to update schema for ({filePath}). Exception message: {exception.Message}");
+            throw new WeavingException($"Failed to update schema for ({projectConfigFilePath}). Exception message: {exception.Message}");
         }
     }
 

--- a/Fody/ConfigFileFinder/ConfigFileFinder.cs
+++ b/Fody/ConfigFileFinder/ConfigFileFinder.cs
@@ -99,8 +99,7 @@ public static class ConfigFileFinder
 
     static void CreateSchemaForConfig(string projectConfigFilePath, IEnumerable<WeaverEntry> weavers)
     {
-        var template = Fody.Properties.Resources.FodyWeavers_SchemaTemplate;
-        var schema = XDocument.Parse(template);
+        var schema = XDocument.Parse(Fody.Properties.Resources.FodyWeavers_SchemaTemplate);
 
         var baseNode = schema.Descendants().First(item => item.Name == schemaNamespace.GetName("all"));
 

--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -110,7 +110,7 @@ public partial class Processor
             }
         }
 
-        ConfigFileFinder.EnsureSchemaIsUpToDate(ProjectDirectory, Weavers, GenerateXsd);
+        ConfigFileFinder.EnsureSchemaIsUpToDate(SolutionDirectory, ProjectDirectory, Weavers, GenerateXsd);
 
         Weavers = Weavers
             .Where(weaver => weaver.Element != null)

--- a/Tests/Fody/ConfigFileFinderTests.cs
+++ b/Tests/Fody/ConfigFileFinderTests.cs
@@ -12,22 +12,32 @@ public class ConfigFileFinderTests  :
     static XNamespace schemaInstanceNamespace = XNamespace.Get("http://www.w3.org/2001/XMLSchema-instance");
 
     string testDir;
+    string slnDir;
+
     string xmlPath;
     string xsdPath;
+
+    string slnXmlPath;
+    string slnXsdPath;
 
     public ConfigFileFinderTests(ITestOutputHelper output) :
         base(output)
     {
         testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
+        slnDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
         Directory.CreateDirectory(testDir);
+        Directory.CreateDirectory(slnDir);
 
         xmlPath = Path.Combine(testDir, "FodyWeavers.xml");
         xsdPath = Path.Combine(testDir, "FodyWeavers.xsd");
+        slnXmlPath = Path.Combine(slnDir, "FodyWeavers.xml");
+        slnXsdPath = Path.Combine(slnDir, "FodyWeavers.xsd");
     }
 
     public override void Dispose()
     {
         Directory.Delete(testDir, true);
+        Directory.Delete(slnDir, true);
         base.Dispose();
     }
 
@@ -58,9 +68,9 @@ public class ConfigFileFinderTests  :
             }
         };
 
-        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(Guid.NewGuid().ToString(), testDir, new MockBuildLogger()).ToArray();
+        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(slnDir, testDir, new MockBuildLogger()).ToArray();
 
-        ConfigFileFinder.EnsureSchemaIsUpToDate(testDir, weavers, true);
+        ConfigFileFinder.EnsureSchemaIsUpToDate(slnDir, testDir, weavers, true);
 
         Assert.Single(configFiles);
         Assert.False(configFiles[0].IsGlobal);
@@ -119,8 +129,8 @@ public class ConfigFileFinderTests  :
             }
         };
 
-        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(Guid.NewGuid().ToString(), testDir, new MockBuildLogger()).ToArray();
-        ConfigFileFinder.EnsureSchemaIsUpToDate(testDir, weavers, true);
+        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(slnDir, testDir, new MockBuildLogger()).ToArray();
+        ConfigFileFinder.EnsureSchemaIsUpToDate(slnDir, testDir, weavers, true);
 
         Assert.Single(configFiles);
         Assert.Equal(xmlPath, configFiles[0].FilePath);
@@ -149,8 +159,8 @@ public class ConfigFileFinderTests  :
             }
         };
 
-        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(Guid.NewGuid().ToString(), testDir, new MockBuildLogger()).ToArray();
-        ConfigFileFinder.EnsureSchemaIsUpToDate(testDir, weavers, false);
+        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(slnDir, testDir, new MockBuildLogger()).ToArray();
+        ConfigFileFinder.EnsureSchemaIsUpToDate(slnDir, testDir, weavers, false);
 
         Assert.Single(configFiles);
         Assert.Equal(xmlPath, configFiles[0].FilePath);
@@ -160,6 +170,110 @@ public class ConfigFileFinderTests  :
         var xml = XDocumentEx.Load(xmlPath);
         Assert.NotNull(xml.Root);
         Assert.Null(xml.Root.Attribute(schemaInstanceNamespace + "noNamespaceSchemaLocation"));
+    }
+
+    [Fact]
+    public void ShouldOptOutOfXsdThroughMSBuildProperty_OnlySolutionWideConfig()
+    {
+        // Deliberately not writing the file in the project dir.
+        if (File.Exists(xmlPath))
+            File.Delete(xmlPath);
+        File.WriteAllText(slnXmlPath, @"
+<Weavers>
+  <TestWeaver />
+</Weavers>
+");
+
+        var weavers = new[]
+        {
+            new WeaverEntry
+            {
+                AssemblyPath = @"something\TestWeaver.Fody.dll"
+            }
+        };
+
+        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(slnDir, testDir, new MockBuildLogger()).ToArray();
+        ConfigFileFinder.EnsureSchemaIsUpToDate(slnDir, testDir, weavers, false);
+
+        Assert.Single(configFiles);
+        Assert.Equal(slnXmlPath, configFiles[0].FilePath);
+
+        Assert.False(File.Exists(slnXsdPath));
+
+        var xml = XDocumentEx.Load(slnXmlPath);
+        Assert.NotNull(xml.Root);
+        Assert.Null(xml.Root.Attribute(schemaInstanceNamespace + "noNamespaceSchemaLocation"));
+    }
+
+    [Fact]
+    public void ShouldCreateXsd_OnlySolutionWideConfig()
+    {
+        File.WriteAllText(slnXmlPath, @"
+<Weavers>
+  <TestWeaver />
+</Weavers>
+");
+
+        File.WriteAllText(Path.Combine(slnDir, "WeaverWithSchema.Fody.xcf"), @"
+<xs:complexType xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <xs:attribute name=""TestAttribute"" type=""xs:string"" />
+</xs:complexType>
+");
+
+        var weavers = new[]
+        {
+            new WeaverEntry
+            {
+                AssemblyPath = @"something\TestWeaver.Fody.dll"
+            },
+            new WeaverEntry
+            {
+                AssemblyPath = Path.Combine(slnDir, "WeaverWithSchema.Fody.dll")
+            }
+        };
+
+        var configFiles = ConfigFileFinder.FindWeaverConfigFiles(slnDir, testDir, new MockBuildLogger()).ToArray();
+
+        ConfigFileFinder.EnsureSchemaIsUpToDate(slnDir, testDir, weavers, true);
+
+        Assert.Single(configFiles);
+        Assert.True(configFiles[0].IsGlobal);
+        Assert.Equal(slnXmlPath, configFiles[0].FilePath);
+
+        Assert.True(File.Exists(slnXsdPath));
+
+        var xml = XDocumentEx.Load(slnXmlPath);
+        Assert.NotNull(xml.Root);
+        Assert.Equal("FodyWeavers.xsd", xml.Root.Attribute(schemaInstanceNamespace + "noNamespaceSchemaLocation")?.Value);
+
+        var xsd = XDocumentEx.Load(slnXsdPath);
+        Assert.NotNull(xsd.Root);
+        var elements = xsd.Root.Descendants(schemaNamespace + "all").First().Elements().ToList();
+
+        Assert.Equal(2, elements.Count);
+
+        var defaultElem = elements[0];
+        Assert.Equal("element", defaultElem.Name.LocalName);
+        Assert.Equal("TestWeaver", defaultElem.Attribute("name")?.Value);
+        Assert.Equal("xs:anyType", defaultElem.Attribute("type")?.Value);
+        Assert.Equal("0", defaultElem.Attribute("minOccurs")?.Value);
+        Assert.Equal("1", defaultElem.Attribute("maxOccurs")?.Value);
+
+        var elemWithSchema = elements[1];
+        Assert.Equal("element", elemWithSchema.Name.LocalName);
+        Assert.Equal("WeaverWithSchema", elemWithSchema.Attribute("name")?.Value);
+        Assert.Null(elemWithSchema.Attribute("type"));
+        Assert.Equal("0", elemWithSchema.Attribute("minOccurs")?.Value);
+        Assert.Equal("1", elemWithSchema.Attribute("maxOccurs")?.Value);
+
+        var elemWithSchemaType = Assert.Single(elemWithSchema.Elements());
+        Assert.NotNull(elemWithSchemaType);
+        Assert.Equal("complexType", elemWithSchemaType.Name.LocalName);
+
+        var elemWithSchemaTypeAttr = Assert.Single(elemWithSchemaType.Elements());
+        Assert.NotNull(elemWithSchemaTypeAttr);
+        Assert.Equal("attribute", elemWithSchemaTypeAttr.Name.LocalName);
+        Assert.Equal("TestAttribute", elemWithSchemaTypeAttr.Attribute("name")?.Value);
     }
 
     [Fact]
@@ -179,8 +293,8 @@ public class ConfigFileFinderTests  :
             }
         };
 
-        var configs = ConfigFileFinder.FindWeaverConfigFiles(Guid.NewGuid().ToString(), testDir, new MockBuildLogger()).ToArray();
-        ConfigFileFinder.EnsureSchemaIsUpToDate(testDir, weavers, false);
+        var configs = ConfigFileFinder.FindWeaverConfigFiles(slnDir, testDir, new MockBuildLogger()).ToArray();
+        ConfigFileFinder.EnsureSchemaIsUpToDate(slnDir, testDir, weavers, false);
 
         Assert.Single(configs);
         Assert.Equal(xmlPath, configs[0].FilePath);

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="ApprovalTests" Version="4.0.0" />
     <PackageReference Include="ObjectApproval" Version="9.1.0" />
     <PackageReference Include="Xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="XunitLogger" Version="2.3.1" />
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />


### PR DESCRIPTION
#### Description

Right now, having a solution level config file without a project level one is supported. But `EnsureSchemaIsUpToDate` doesn't care about that and will therefore throw an exception if it doesn't find a config file in the project directory (it only checks for project level, even though earlier in the callstack if neither project or solution level one is found a project level one is generated automatically).
This PR avoids throwing exception during `EnsureSchemaIsUpToDate` when a solution config is specified.

#### The solution

During `EnsureSchemaIsUpToDate`, a `string solutionDirectory` argument has been added, so that both project and solution file can be checked. Will only try to ensure schema is up to date if the respective file exists.


#### Todos

 * [ ] Related issues
 * [x] Tests
 * [ ] Documentation