### PR TITLE
EventHandler Memoryleak in InnerWeaver

### DIFF
--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -103,7 +103,7 @@ public partial class InnerWeaver :
             TypeCache = new TypeCache(assemblyResolver.Resolve);
             InitialiseWeavers();
 
-            TypeCache.BuildAssembliesToScan(weaverInstances.Select(x=>x.Instance));
+            TypeCache.BuildAssembliesToScan(weaverInstances.Select(x => x.Instance));
             InitialiseTypeSystem();
             ExecuteWeavers();
             AddWeavingInfo();
@@ -116,11 +116,11 @@ public partial class InnerWeaver :
         }
         catch (Exception exception)
         {
-            AppDomain.CurrentDomain.AssemblyResolve -= assemblyResolve;
             Logger.LogException(exception);
         }
         finally
         {
+            AppDomain.CurrentDomain.AssemblyResolve -= assemblyResolve;
             ModuleDefinition?.Dispose();
             CleanupTempSymbolsAndAssembly();
             assemblyResolver?.Dispose();


### PR DESCRIPTION
Assembly Resolve event was only unregistered when an exception was thrown. During normal processing the event registration remains and leads to a memory leak. The loaded assemblies could no longer be freed and kept in memory as long as the msbuild process was running. In our project this leak lead to build aborts because of OutOfMemoryException.  This pull request addresses the issue and fixes it by deregistering the event in the normal flow of execution.

For more detail see: #752 