### PR TITLE
qualify ProcessedByFody namespace with "_Fody"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>6.0.7</Version>
+    <Version>6.0.8</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>8.0</LangVersion>
     <NoWarn>CS1591;CS0618</NoWarn>

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -234,7 +234,7 @@ public partial class InnerWeaver :
         var startNew = Stopwatch.StartNew();
 
         const TypeAttributes typeAttributes = TypeAttributes.NotPublic | TypeAttributes.Class;
-        var typeDefinition = new TypeDefinition(ModuleDefinition.Assembly.Name.Name, "ProcessedByFody", typeAttributes, TypeSystem.ObjectReference);
+        var typeDefinition = new TypeDefinition($"{ModuleDefinition.Assembly.Name.Name}_Fody", "ProcessedByFody", typeAttributes, TypeSystem.ObjectReference);
         ModuleDefinition.Types.Add(typeDefinition);
 
         AddVersionField(typeof(IInnerWeaver).Assembly, "FodyVersion", typeDefinition);


### PR DESCRIPTION
to prevent naming conflicts
