### PR TITLE
Adjust nullable reference types annotations

### DIFF
--- a/Fody/BuildLogger.cs
+++ b/Fody/BuildLogger.cs
@@ -34,12 +34,12 @@ public class BuildLogger :
         BuildEngine.LogMessageEvent(new BuildMessageEventArgs(GetIndent() + PrependMessage(message), "", "Fody", (Microsoft.Build.Framework.MessageImportance)MessageImportanceDefaults.Info));
     }
 
-    public virtual void LogWarning(string message, string code)
+    public virtual void LogWarning(string message, string? code)
     {
         LogWarning(message, null, 0, 0, 0, 0, code);
     }
 
-    public virtual void LogWarning(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string code)
+    public virtual void LogWarning(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string? code)
     {
         BuildEngine.LogWarningEvent(new BuildWarningEventArgs("", code ?? "", file, lineNumber, columnNumber, endLineNumber, endColumnNumber, PrependMessage(message), "", "Fody"));
     }

--- a/Fody/DomainAssemblyResolver.cs
+++ b/Fody/DomainAssemblyResolver.cs
@@ -9,7 +9,7 @@ public static class DomainAssemblyResolver
         AppDomain.CurrentDomain.AssemblyResolve += (sender, args) => GetAssembly(args.Name);
     }
 
-    public static Assembly GetAssembly(string name)
+    public static Assembly? GetAssembly(string name)
     {
         return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => string.Equals(x.FullName, name, StringComparison.OrdinalIgnoreCase));
     }

--- a/Fody/ExtractConstants.cs
+++ b/Fody/ExtractConstants.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 static class ExtractConstants
 {
-    internal static List<string> GetConstants(this string input)
+    internal static List<string> GetConstants(this string? input)
     {
         if (input == null)
         {

--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -2,17 +2,16 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Xml.Linq;
 
 public partial class Processor
 {
     public string AssemblyFilePath = null!;
     public string IntermediateDirectory = null!;
-    public string KeyFilePath = null!;
+    public string? KeyFilePath;
     public bool SignAssembly;
     public string ProjectDirectory = null!;
     public string ProjectFilePath = null!;
-    public string DocumentationFilePath = null!;
+    public string? DocumentationFilePath;
     public string References = null!;
     public string SolutionDirectory = null!;
     public List<WeaverEntry> Weavers = null!;

--- a/Fody/Verify/VerifyTask.cs
+++ b/Fody/Verify/VerifyTask.cs
@@ -6,9 +6,9 @@ namespace Fody
     public class VerifyTask :
         Task
     {
-        public string? NCrunchOriginalSolutionDirectory { get; set; } = null!;
+        public string? NCrunchOriginalSolutionDirectory { get; set; }
         public string? SolutionDirectory { get; set; }
-        public string DefineConstants { get; set; } = null!;
+        public string? DefineConstants { get; set; }
         [Required]
         public string ProjectDirectory { get; set; } = null!;
         [Required]

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -17,8 +17,8 @@ namespace Fody
 
         [Required]
         public string IntermediateDirectory { get; set; } = null!;
-        public string KeyOriginatorFile { get; set; } = null!;
-        public string AssemblyOriginatorKeyFile { get; set; } = null!;
+        public string? KeyOriginatorFile { get; set; }
+        public string? AssemblyOriginatorKeyFile { get; set; }
 
         public bool SignAssembly { get; set; }
 
@@ -28,7 +28,7 @@ namespace Fody
         [Required]
         public string ProjectFile { get; set; } = null!;
 
-        public string DocumentationFile { get; set; } = null!;
+        public string? DocumentationFile { get; set; }
 
         [Required]
         public string References { get; set; } = null!;
@@ -38,12 +38,12 @@ namespace Fody
         [Required]
         public ITaskItem[] WeaverFiles { get; set; } = null!;
         public string? WeaverConfiguration { get; set; }
-        public ITaskItem[] PackageReferences { get; set; } = null!;
+        public ITaskItem[]? PackageReferences { get; set; }
 
-        public string NCrunchOriginalSolutionDirectory { get; set; } = null!;
-        public string SolutionDirectory { get; set; } = null!;
+        public string? NCrunchOriginalSolutionDirectory { get; set; }
+        public string? SolutionDirectory { get; set; }
 
-        public string DefineConstants { get; set; } = null!;
+        public string? DefineConstants { get; set; }
 
         [Output]
         public string ExecutedWeavers { get; private set; } = null!;

--- a/FodyCommon/IInnerWeaver.cs
+++ b/FodyCommon/IInnerWeaver.cs
@@ -5,7 +5,7 @@ public interface IInnerWeaver : IDisposable
 {
     string AssemblyFilePath { get; set; }
     string References { get; set; }
-    string KeyFilePath { get; set; }
+    string? KeyFilePath { get; set; }
     bool SignAssembly { get; set; }
     List<WeaverEntry> Weavers { get; set; }
     ILogger Logger { get; set; }
@@ -15,7 +15,7 @@ public interface IInnerWeaver : IDisposable
     List<string> DefineConstants { get; set; }
     string ProjectDirectoryPath { get; set; }
     string ProjectFilePath { get; set; }
-    string DocumentationFilePath { get; set; }
+    string? DocumentationFilePath { get; set; }
     #if(NETSTANDARD)
     IsolatedAssemblyLoadContext LoadContext { get; set; }
     #endif

--- a/FodyCommon/ILogger.cs
+++ b/FodyCommon/ILogger.cs
@@ -7,9 +7,9 @@ public interface ILogger
     void LogDebug(string message);
     void LogInfo(string message);
     void LogMessage(string message, int level);
-    void LogWarning(string message, string code="");
-    void LogWarning(string message, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string code="");
-    void LogError(string message, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber);
+    void LogWarning(string message, string? code="");
+    void LogWarning(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string? code="");
+    void LogError(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber);
     void LogError(string message);
     bool ErrorOccurred { get; }
 }

--- a/FodyCommon/WeaverEntry.cs
+++ b/FodyCommon/WeaverEntry.cs
@@ -17,7 +17,7 @@ public class WeaverEntry
     /// <summary>
     /// The content of the XML element containing the configuration.
     /// </summary>
-    public string Element = null!;
+    public string? Element;
 
     /// <summary>
     /// The source of the configuration element.
@@ -52,7 +52,7 @@ public class WeaverEntry
     /// <summary>
     /// The type name of the weaver class as read from the configuration; maybe <c>null</c> to use the default "ModuleWeaver".
     /// </summary>
-    public string ConfiguredTypeName = null!;
+    public string? ConfiguredTypeName;
 
     /// <summary>
     /// True if a PackageReference element item matching the weaver has been found.
@@ -87,7 +87,7 @@ public class WeaverEntry
 
     class WeaverNameComparer : IEqualityComparer<WeaverEntry>
     {
-        public bool Equals(WeaverEntry x, WeaverEntry y)
+        public bool Equals(WeaverEntry? x, WeaverEntry? y)
         {
             return x?.ElementName == y?.ElementName;
         }

--- a/FodyHelpers/BaseModuleWeaver.cs
+++ b/FodyHelpers/BaseModuleWeaver.cs
@@ -180,7 +180,7 @@ namespace Fody
         /// if generating the documentation file is enabled in the project.
         /// A copy of @(DocFileItem->'%(FullPath)').
         /// </summary>
-        public string DocumentationFilePath { get; set; } = null!;
+        public string? DocumentationFilePath { get; set; }
 
         /// <summary>
         /// The full directory path of the current weaver.

--- a/FodyHelpers/Testing/Ildasm.cs
+++ b/FodyHelpers/Testing/Ildasm.cs
@@ -18,7 +18,7 @@ namespace Fody
 
         public static readonly bool FoundIldasm;
 
-        public static string Decompile(string assemblyPath, string item = "")
+        public static string Decompile(string assemblyPath, string? item = "")
         {
             Guard.AgainstNullAndEmpty(nameof(assemblyPath), assemblyPath);
             if (!FoundIldasm)

--- a/FodyHelpers/Testing/SymbolReaderProvider.cs
+++ b/FodyHelpers/Testing/SymbolReaderProvider.cs
@@ -12,7 +12,7 @@ class SymbolReaderProvider : ISymbolReaderProvider
         inner = new DefaultSymbolReaderProvider(false);
     }
 
-    public ISymbolReader GetSymbolReader(ModuleDefinition module, string fileName)
+    public ISymbolReader? GetSymbolReader(ModuleDefinition module, string fileName)
     {
         var symbolReader = inner.GetSymbolReader(module, fileName);
         if (symbolReader != null)
@@ -24,7 +24,7 @@ class SymbolReaderProvider : ISymbolReaderProvider
         return inner.GetSymbolReader(module, uwpAssemblyPath);
     }
 
-    public ISymbolReader GetSymbolReader(ModuleDefinition module, Stream symbolStream)
+    public ISymbolReader? GetSymbolReader(ModuleDefinition module, Stream symbolStream)
     {
         throw new NotSupportedException();
     }

--- a/FodyIsolated/AssemblyResolverHelper.cs
+++ b/FodyIsolated/AssemblyResolverHelper.cs
@@ -2,7 +2,7 @@ using Mono.Cecil;
 
 public static class AssemblyResolverHelper 
 {
-    public static AssemblyDefinition Resolve(this IAssemblyResolver resolver,  string assemblyName)
+    public static AssemblyDefinition? Resolve(this IAssemblyResolver resolver, string assemblyName)
     {
         return resolver.Resolve(new AssemblyNameReference(assemblyName, null));
     }

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -20,12 +20,12 @@ public partial class InnerWeaver :
 {
     public string ProjectDirectoryPath { get; set; } = null!;
     public string ProjectFilePath { get; set; } = null!;
-    public string DocumentationFilePath { get; set; } = null!;
+    public string? DocumentationFilePath { get; set; }
     public string AssemblyFilePath { get; set; } = null!;
     public string SolutionDirectoryPath { get; set; } = null!;
     public string References { get; set; } = null!;
     public List<WeaverEntry> Weavers { get; set; } = null!;
-    public string KeyFilePath { get; set; } = null!;
+    public string? KeyFilePath { get; set; }
     public bool SignAssembly { get; set; }
     public ILogger Logger { get; set; }= null!;
     public string IntermediateDirectoryPath { get; set; } = null!;
@@ -142,16 +142,25 @@ public partial class InnerWeaver :
             }
 
             var weaverHolder = InitialiseWeaver(weaverConfig);
-            weaverInstances.Add(weaverHolder);
+            if (weaverHolder != null)
+            {
+                weaverInstances.Add(weaverHolder);
+            }
         }
     }
 
-    WeaverHolder InitialiseWeaver(WeaverEntry weaverConfig)
+    WeaverHolder? InitialiseWeaver(WeaverEntry weaverConfig)
     {
         Logger.LogDebug($"Weaver '{weaverConfig.AssemblyPath}'.");
         Logger.LogDebug("  Initializing weaver");
         var assembly = LoadWeaverAssembly(weaverConfig.AssemblyPath);
         var weaverType = assembly.FindType(weaverConfig.TypeName);
+
+        if (weaverType == null)
+        {
+            Logger.LogError($"Could not find weaver type {weaverConfig.TypeName} in {weaverConfig.WeaverName}");
+            return null;
+        }
 
         var delegateHolder = weaverType.GetDelegateHolderFromCache();
         var weaverInstance = delegateHolder();

--- a/FodyIsolated/TypeFinder.cs
+++ b/FodyIsolated/TypeFinder.cs
@@ -5,7 +5,7 @@ using Fody;
 
 public static class TypeFinder
 {
-    public static Type FindType(this Assembly readAssembly, string typeName)
+    public static Type? FindType(this Assembly readAssembly, string typeName)
     {
         try
         {

--- a/Tests/Fody/MockBuildLogger.cs
+++ b/Tests/Fody/MockBuildLogger.cs
@@ -21,15 +21,15 @@
     {
     }
 
-    public void LogWarning(string message, string code)
+    public void LogWarning(string message, string? code)
     {
     }
 
-    public void LogWarning(string message, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string code)
+    public void LogWarning(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string? code)
     {
     }
 
-    public void LogError(string message, string file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber)
+    public void LogError(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber)
     {
     }
 

--- a/Tests/FodyIsolated/AssemblyResolverTests.cs
+++ b/Tests/FodyIsolated/AssemblyResolverTests.cs
@@ -22,7 +22,7 @@ public class AssemblyResolverTests :
 
             var resolver = new AssemblyResolver(logger, new[] {assemblyPath});
             using var resolvedAssembly = resolver.Resolve(assembly.GetName().Name);
-            Assert.Equal(assembly.FullName, resolvedAssembly.FullName);
+            Assert.Equal(assembly.FullName, resolvedAssembly!.FullName);
         }
         finally
         {


### PR DESCRIPTION
I noticed a few nullable reference type annotations were off when doing my previous changes, so I quickly reviewed the annotations in the Fody projects. It doesn't fix everything, since it would require large changes to the codebase (there are still many properties with a `= null!` initializer), but it's a step in the right direction.
