### PR TITLE
Keep the original file extension in WeaverTestHelper.ExecuteTestRun

### DIFF
--- a/DummyExeAssembly/DummyExeAssembly.csproj
+++ b/DummyExeAssembly/DummyExeAssembly.csproj
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+</Project>

--- a/DummyExeAssembly/Program.cs
+++ b/DummyExeAssembly/Program.cs
@@ -1,0 +1,9 @@
+﻿namespace DummyExeAssembly
+{
+    static class Program
+    {
+        static void Main()
+        {
+        }
+    }
+}

--- a/Fody.sln
+++ b/Fody.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FodyHelpers.Tests", "FodyHe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithNoSymbols", "AssemblyWithNoSymbols\AssemblyWithNoSymbols.csproj", "{7E18A70B-31D6-4435-BD88-1415078B7D84}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DummyExeAssembly", "DummyExeAssembly\DummyExeAssembly.csproj", "{BF644933-57CD-48A0-AC2B-FCF46459359B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,6 +87,10 @@ Global
 		{7E18A70B-31D6-4435-BD88-1415078B7D84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E18A70B-31D6-4435-BD88-1415078B7D84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E18A70B-31D6-4435-BD88-1415078B7D84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF644933-57CD-48A0-AC2B-FCF46459359B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF644933-57CD-48A0-AC2B-FCF46459359B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF644933-57CD-48A0-AC2B-FCF46459359B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF644933-57CD-48A0-AC2B-FCF46459359B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FodyHelpers.Tests/FodyHelpers.Tests.csproj
+++ b/FodyHelpers.Tests/FodyHelpers.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
@@ -20,12 +20,12 @@
     <ProjectReference Include="..\SampleWeaver.Fody\SampleWeaver.Fody.csproj" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net472'">
+  <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Reference Include="Mono.Cecil" HintPath="..\Lib\Cecil\net40\Mono.Cecil.dll" />
     <Reference Include="Mono.Cecil.Pdb" HintPath="..\Lib\Cecil\net40\Mono.Cecil.Pdb.dll" />
     <Reference Include="Mono.Cecil.Rocks" HintPath="..\Lib\Cecil\net40\Mono.Cecil.Rocks.dll" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.2'">
+  <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">
     <Reference Include="Mono.Cecil" HintPath="..\Lib\Cecil\netstandard2.0\Mono.Cecil.dll" />
     <Reference Include="Mono.Cecil.Pdb" HintPath="..\Lib\Cecil\netstandard2.0\Mono.Cecil.Pdb.dll" />
     <Reference Include="Mono.Cecil.Rocks" HintPath="..\Lib\Cecil\netstandard2.0\Mono.Cecil.Rocks.dll" />

--- a/FodyHelpers.Tests/FodyHelpers.Tests.csproj
+++ b/FodyHelpers.Tests/FodyHelpers.Tests.csproj
@@ -14,6 +14,7 @@
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <ProjectReference Include="..\DummyAssembly\DummyAssembly.csproj" />
+    <ProjectReference Include="..\DummyExeAssembly\DummyExeAssembly.csproj" />
     <ProjectReference Include="..\FodyCommon\FodyCommon.csproj" />
     <ProjectReference Include="..\FodyHelpers\FodyHelpers.csproj" />
     <ProjectReference Include="..\FodyIsolated\FodyIsolated.csproj" />

--- a/FodyHelpers.Tests/IldasmTests.cs
+++ b/FodyHelpers.Tests/IldasmTests.cs
@@ -42,7 +42,7 @@ public class IldasmTests
     {
         var assembly = typeof(Class1).Assembly;
 
-        var uri = new UriBuilder(assembly.CodeBase);
+        var uri = new UriBuilder(assembly.CodeBase!);
         return Uri.UnescapeDataString(uri.Path);
     }
 }

--- a/FodyHelpers.Tests/WeaverTestHelperTests.WithCustomExeAssemblyName.verified.txt
+++ b/FodyHelpers.Tests/WeaverTestHelperTests.WithCustomExeAssemblyName.verified.txt
@@ -1,0 +1,10 @@
+{
+  Messages: [
+    {
+      Text: 	Removing reference to 'FodyHelpers.Tests'.,
+      MessageImportance: Low
+    }
+  ],
+  AssemblyPath: {CurrentDirectory}\fodytemp\NewName.exe,
+  FullName: NewName, Version=0.0.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03
+}

--- a/FodyHelpers.Tests/WeaverTestHelperTests.cs
+++ b/FodyHelpers.Tests/WeaverTestHelperTests.cs
@@ -41,6 +41,25 @@ public class WeaverTestHelperTests
     }
 
     [Fact]
+    public Task WithCustomExeAssemblyName()
+    {
+        var assemblyPath = Path.Combine(Environment.CurrentDirectory, "DummyExeAssembly.exe");
+        try
+        {
+            var weaver = new TargetWeaver();
+            var result = weaver.ExecuteTestRun(
+                assemblyPath: assemblyPath,
+                assemblyName: "NewName");
+            return Verify(result);
+        }
+        catch (BadImageFormatException) when (AppContext.TargetFrameworkName!.StartsWith(".NETCoreApp"))
+        {
+            // The .NET Core DummyExeAssembly.exe file makes Mono.Cecil throw a BadImageFormatException ¯\_(ツ)_/¯
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
     public Task WeaverUsingSymbols()
     {
         var assemblyPath = Path.Combine(Environment.CurrentDirectory, "DummyAssembly.dll");

--- a/FodyHelpers/Testing/WeaverTestHelper.cs
+++ b/FodyHelpers/Testing/WeaverTestHelper.cs
@@ -37,7 +37,8 @@ namespace Fody
             }
             else
             {
-                targetFileName = assemblyName + ".dll";
+                var extension = Path.GetExtension(assemblyPath);
+                targetFileName = assemblyName + (string.IsNullOrEmpty(extension) ? ".dll" : extension);
             }
 
             var targetAssemblyPath = Path.Combine(fodyTempDir, targetFileName);

--- a/Tests/FodyIsolated/AssemblyResolverTests.cs
+++ b/Tests/FodyIsolated/AssemblyResolverTests.cs
@@ -18,7 +18,7 @@ public class AssemblyResolverTests
             File.Copy(assembly.Location, assemblyPath, true);
 
             var resolver = new AssemblyResolver(logger, new[] {assemblyPath});
-            using var resolvedAssembly = resolver.Resolve(assembly.GetName().Name);
+            using var resolvedAssembly = resolver.Resolve(assembly.GetName().Name!);
             Assert.Equal(assembly.FullName, resolvedAssembly!.FullName);
         }
         finally

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -30,13 +30,13 @@
     <Content Include="Fody\ProjectWeaversReaderTests\*.xml" CopyToOutputDirectory="Always" />
     <Content Include="Fody\ProjectWeaversReaderTests\*.txt" CopyToOutputDirectory="Always" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'net472'">
+  <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETFramework'">
     <Reference Include="Mono.Cecil" HintPath="..\Lib\Cecil\net40\Mono.Cecil.dll" />
     <Reference Include="Mono.Cecil.Pdb" HintPath="..\Lib\Cecil\net40\Mono.Cecil.Pdb.dll" />
     <Reference Include="Mono.Cecil.Rocks" HintPath="..\Lib\Cecil\net40\Mono.Cecil.Rocks.dll" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" Aliases="msbuild4" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.2'">
+  <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">
     <Reference Include="Mono.Cecil" HintPath="..\Lib\Cecil\netstandard2.0\Mono.Cecil.dll" />
     <Reference Include="Mono.Cecil.Pdb" HintPath="..\Lib\Cecil\netstandard2.0\Mono.Cecil.Pdb.dll" />
     <Reference Include="Mono.Cecil.Rocks" HintPath="..\Lib\Cecil\netstandard2.0\Mono.Cecil.Rocks.dll" />


### PR DESCRIPTION
Before this pull request, when supplying a custom assembly name, the target file would be renamed with `.dll` when weaving an `.exe` file. This was confusing.