### PR TITLE
Add new FodyRemovedReferenceCopyLocalPaths MSBuild item

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -87,6 +87,8 @@
     </Fody.UpdateReferenceCopyLocalTask>
 
     <ItemGroup>
+      <FodyRemovedReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths)" />
+      <FodyRemovedReferenceCopyLocalPaths Remove="@(FodyUpdatedReferenceCopyLocalPaths)" />
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" />
       <ReferenceCopyLocalPaths Include="@(FodyUpdatedReferenceCopyLocalPaths)" />
     </ItemGroup>


### PR DESCRIPTION
When `ReferenceCopyLocalPaths` is updated by Fody, the information of _which_ `ReferenceCopyLocalPaths` were removed is lost.

Why is this important to have this information? Because when using Costura and the `Publish` MSBuild target, the dlls that were removed from the build output directory end up in the publish output directory anyway, even though they are already embedded in the executable. With this new information available, it becomes possible to fix the publishing task like this:

```xml
<Target Name="RemoveAlreadyEmbeddedFilesFromPublish" AfterTargets="ComputeResolvedFilesToPublishList">
  <ItemGroup>
    <!-- In order not to publish dll files (already embedded by Costura.Fody) -->
    <ResolvedFileToPublish Remove="@(FodyRemovedReferenceCopyLocalPaths)" />
  </ItemGroup>
</Target>
```

I plan to submit this fix to Costura.Fody but I need the list of removed `ReferenceCopyLocalPaths` from Fody itself first.