### PR TITLE
Fix #985: Build fails when using dotnet cli and strong assembly

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -47,6 +47,7 @@
         SolutionDirectory="$(SolutionDir)"
         References="@(ReferencePath)"
         SignAssembly="$(SignAssembly)"
+        DelaySign="$(DelaySign)"
         ReferenceCopyLocalFiles="@(ReferenceCopyLocalPaths)"
         DefineConstants="$(DefineConstants)"
         DocumentationFile="@(DocFileItem->'%(FullPath)')"

--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -9,6 +9,7 @@ public partial class Processor
     public string IntermediateDirectory = null!;
     public string? KeyFilePath;
     public bool SignAssembly;
+    public bool DelaySign;
     public string ProjectDirectory = null!;
     public string ProjectFilePath = null!;
     public string? DocumentationFilePath;
@@ -134,6 +135,7 @@ public partial class Processor
             innerWeaver.KeyFilePath = KeyFilePath;
             innerWeaver.ReferenceCopyLocalPaths = ReferenceCopyLocalPaths;
             innerWeaver.SignAssembly = SignAssembly;
+            innerWeaver.DelaySign = DelaySign;
             innerWeaver.Logger = Logger;
             innerWeaver.SolutionDirectoryPath = SolutionDirectory;
             innerWeaver.Weavers = Weavers;

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -21,6 +21,7 @@ namespace Fody
         public string? AssemblyOriginatorKeyFile { get; set; }
 
         public bool SignAssembly { get; set; }
+        public bool DelaySign { get; set; }
 
         [Required]
         public string ProjectDirectory { get; set; } = null!;
@@ -71,6 +72,7 @@ namespace Fody
                 IntermediateDirectory = IntermediateDirectory,
                 KeyFilePath = KeyOriginatorFile ?? AssemblyOriginatorKeyFile,
                 SignAssembly = SignAssembly,
+                DelaySign = DelaySign,
                 ProjectDirectory = ProjectDirectory,
                 ProjectFilePath = ProjectFile,
                 DocumentationFilePath = DocumentationFile,

--- a/FodyCommon/IInnerWeaver.cs
+++ b/FodyCommon/IInnerWeaver.cs
@@ -7,6 +7,7 @@ public interface IInnerWeaver : IDisposable
     string References { get; set; }
     string? KeyFilePath { get; set; }
     bool SignAssembly { get; set; }
+    bool DelaySign { get; set; }
     List<WeaverEntry> Weavers { get; set; }
     ILogger Logger { get; set; }
     string IntermediateDirectoryPath { get; set; }

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -27,13 +27,14 @@ public partial class InnerWeaver :
     public List<WeaverEntry> Weavers { get; set; } = null!;
     public string? KeyFilePath { get; set; }
     public bool SignAssembly { get; set; }
-    public ILogger Logger { get; set; }= null!;
+    public bool DelaySign { get; set; }
+    public ILogger Logger { get; set; } = null!;
     public string IntermediateDirectoryPath { get; set; } = null!;
     public List<string> ReferenceCopyLocalPaths { get; set; } = null!;
     public List<string> DefineConstants { get; set; } = null!;
-    #if (NETSTANDARD)
+#if (NETSTANDARD)
     public IsolatedAssemblyLoadContext LoadContext { get; set; } = null!;
-    #endif
+#endif
     bool cancelRequested;
     List<WeaverHolder> weaverInstances = new List<WeaverHolder>();
     Action? cancelDelegate;

--- a/FodyIsolated/StrongNameKeyFinder.cs
+++ b/FodyIsolated/StrongNameKeyFinder.cs
@@ -34,24 +34,27 @@ public partial class InnerWeaver
             {
                 try
                 {
+                    Logger.LogDebug("Extract public key from key file for signing.");
+
                     StrongNameKeyPair = new StrongNameKeyPair(fileBytes);
                     // Ensure that we can generate the public key from the key file. This requires the private key to
                     // work. If we cannot generate the public key, an ArgumentException will be thrown. In this case,
-                    // the assembly is delay-signed with a public only keyfile.
+                    // the assembly is delay-signed with a public only key-file.
                     // Note: The NETSTANDARD implementation of StrongNameKeyPair.PublicKey does never throw here.
                     PublicKey = StrongNameKeyPair.PublicKey;
                     return;
-
                 }
                 catch (ArgumentException)
                 {
+                    Logger.LogWarning("Failed to extract public key from key file, fall back to delay-signing.");
                 }
             }
 
             // Fall back to delay signing, this was the original behavior, however that does not work in NETSTANDARD (s.a.)
+            Logger.LogDebug("Prepare public key for delay-signing.");
 
-            // We know that we cannot sign the assembly with this keyfile. Let's assume that it is a public
-            // only keyfile and pass along all the bytes.
+            // We know that we cannot sign the assembly with this key-file. Let's assume that it is a public
+            // only key-file and pass along all the bytes.
             StrongNameKeyPair = null;
             PublicKey = fileBytes;
         }

--- a/FodyIsolated/StrongNameKeyFinder.cs
+++ b/FodyIsolated/StrongNameKeyFinder.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using Fody;
 
 #if (NETSTANDARD)
-using StrongNameKeyPair=Mono.Cecil.StrongNameKeyPair;
+using StrongNameKeyPair = Mono.Cecil.StrongNameKeyPair;
 #else
-using StrongNameKeyPair=System.Reflection.StrongNameKeyPair;
+using StrongNameKeyPair = System.Reflection.StrongNameKeyPair;
 #endif
 
 public partial class InnerWeaver
@@ -29,22 +29,31 @@ public partial class InnerWeaver
             }
 
             var fileBytes = File.ReadAllBytes(keyFilePath);
-            StrongNameKeyPair = new StrongNameKeyPair(fileBytes);
 
-            try
+            if (!DelaySign)
             {
-                // Ensure that we can generate the public key from the key file. This requires the private key to
-                // work. If we cannot generate the public key, an ArgumentException will be thrown. In this case,
-                // the assembly is delay-signed with a public only keyfile.
-                PublicKey = StrongNameKeyPair.PublicKey;
+                try
+                {
+                    StrongNameKeyPair = new StrongNameKeyPair(fileBytes);
+                    // Ensure that we can generate the public key from the key file. This requires the private key to
+                    // work. If we cannot generate the public key, an ArgumentException will be thrown. In this case,
+                    // the assembly is delay-signed with a public only keyfile.
+                    // Note: The NETSTANDARD implementation of StrongNameKeyPair.PublicKey does never throw here.
+                    PublicKey = StrongNameKeyPair.PublicKey;
+                    return;
+
+                }
+                catch (ArgumentException)
+                {
+                }
             }
-            catch(ArgumentException)
-            {
-                // We know that we cannot sign the assembly with this keyfile. Let's assume that it is a public
-                // only keyfile and pass along all the bytes.
-                StrongNameKeyPair = null;
-                PublicKey = fileBytes;
-            }
+
+            // Fall back to delay signing, this was the original behavior, however that does not work in NETSTANDARD (s.a.)
+
+            // We know that we cannot sign the assembly with this keyfile. Let's assume that it is a public
+            // only keyfile and pass along all the bytes.
+            StrongNameKeyPair = null;
+            PublicKey = fileBytes;
         }
     }
 
@@ -63,7 +72,7 @@ public partial class InnerWeaver
             .FirstOrDefault(x => x.AttributeType.Name == "AssemblyKeyFileAttribute");
         if (assemblyKeyFileAttribute != null)
         {
-            var keyFileSuffix = (string) assemblyKeyFileAttribute.ConstructorArguments.First().Value;
+            var keyFileSuffix = (string)assemblyKeyFileAttribute.ConstructorArguments.First().Value;
             var keyFilePath = Path.Combine(IntermediateDirectoryPath, keyFileSuffix);
             Logger.LogDebug($"Using strong name key from [AssemblyKeyFileAttribute(\"{keyFileSuffix}\")] '{keyFilePath}'");
             return keyFilePath;


### PR DESCRIPTION
Explicitly handle the `<DelaySign>` property.