### PR TITLE
Cleanup indentation of log messages

### DIFF
--- a/Fody/BuildLogger.cs
+++ b/Fody/BuildLogger.cs
@@ -59,7 +59,7 @@ public class BuildLogger :
 
     string GetIndent()
     {
-        return currentWeaverName == null ? "  " : "    ";
+        return currentWeaverName == null ? "" : "  ";
     }
 
     string PrependMessage(string message)

--- a/Fody/Processor.cs
+++ b/Fody/Processor.cs
@@ -58,7 +58,7 @@ public partial class Processor
         finally
         {
             stopwatch.Stop();
-            Logger.LogInfo($"  Finished Fody {stopwatch.ElapsedMilliseconds}ms.");
+            Logger.LogInfo($"Finished Fody {stopwatch.ElapsedMilliseconds}ms.");
         }
     }
 

--- a/FodyHelpers.Tests/WeaverTestHelperTests.Run.verified.txt
+++ b/FodyHelpers.Tests/WeaverTestHelperTests.Run.verified.txt
@@ -1,7 +1,7 @@
 {
   Messages: [
     {
-      Text: 	Removing reference to 'FodyHelpers.Tests'.,
+      Text: Removing reference to 'FodyHelpers.Tests'.,
       MessageImportance: Low
     }
   ],

--- a/FodyHelpers.Tests/WeaverTestHelperTests.WeaverUsingSymbols.verified.txt
+++ b/FodyHelpers.Tests/WeaverTestHelperTests.WeaverUsingSymbols.verified.txt
@@ -1,7 +1,7 @@
 {
   Messages: [
     {
-      Text: 	Removing reference to 'FodyHelpers.Tests'.,
+      Text: Removing reference to 'FodyHelpers.Tests'.,
       MessageImportance: Low
     }
   ],

--- a/FodyHelpers.Tests/WeaverTestHelperTests.WithCustomAssemblyName.verified.txt
+++ b/FodyHelpers.Tests/WeaverTestHelperTests.WithCustomAssemblyName.verified.txt
@@ -1,7 +1,7 @@
 {
   Messages: [
     {
-      Text: 	Removing reference to 'FodyHelpers.Tests'.,
+      Text: Removing reference to 'FodyHelpers.Tests'.,
       MessageImportance: Low
     }
   ],

--- a/FodyHelpers.Tests/WeaverTestHelperTests.WithCustomExeAssemblyName.verified.txt
+++ b/FodyHelpers.Tests/WeaverTestHelperTests.WithCustomExeAssemblyName.verified.txt
@@ -1,7 +1,7 @@
 {
   Messages: [
     {
-      Text: 	Removing reference to 'FodyHelpers.Tests'.,
+      Text: Removing reference to 'FodyHelpers.Tests'.,
       MessageImportance: Low
     }
   ],

--- a/FodyHelpers/ReferenceCleaner.cs
+++ b/FodyHelpers/ReferenceCleaner.cs
@@ -15,7 +15,7 @@ static class ReferenceCleaner
         }
 
         var weaverLibName = weaver.GetType().Assembly.GetName().Name.ReplaceCaseless(".Fody", "");
-        log($"\tRemoving reference to '{weaverLibName}'.");
+        log($"Removing reference to '{weaverLibName}'.");
 
         var referenceToRemove = module.AssemblyReferences.FirstOrDefault(x => x.Name == weaverLibName);
         if (referenceToRemove != null)

--- a/FodyIsolated/AssemblyReferenceFinder.cs
+++ b/FodyIsolated/AssemblyReferenceFinder.cs
@@ -11,9 +11,9 @@ public partial class InnerWeaver
         SplitReferences = References
             .Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries)
             .ToList();
-        Logger.LogDebug("Reference count=" + SplitReferences.Count);
+        Logger.LogDebug("Reference count: " + SplitReferences.Count);
 
-        var joinedReferences = string.Join(Environment.NewLine + "\t\t", SplitReferences.OrderBy(x => x));
-        Logger.LogDebug($"References:{Environment.NewLine}{joinedReferences}");
+        var joinedReferences = string.Join(Environment.NewLine + "  ", SplitReferences.OrderBy(x => x));
+        Logger.LogDebug($"References:{Environment.NewLine}  {joinedReferences}");
     }
 }

--- a/FodyIsolated/InnerWeaver.cs
+++ b/FodyIsolated/InnerWeaver.cs
@@ -100,7 +100,7 @@ public partial class InnerWeaver :
             var weavingInfoClassName = GetWeavingInfoClassName();
             if (ModuleDefinition.Types.Any(x => x.Name == weavingInfoClassName))
             {
-                Logger.LogWarning($"The assembly has already been processed by Fody. Weaving aborted. Path: {AssemblyFilePath} ");
+                Logger.LogWarning($"The assembly has already been processed by Fody. Weaving aborted. Path: {AssemblyFilePath}");
                 return;
             }
             TypeCache = new TypeCache(assemblyResolver.Resolve);
@@ -195,8 +195,8 @@ public partial class InnerWeaver :
 
                 Logger.SetCurrentWeaverName(weaver.Config.ElementName);
                 var startNew = Stopwatch.StartNew();
-                Logger.LogInfo("  Executing Weaver ");
-                Logger.LogDebug($"  Configuration source: {weaver.Config.ConfigurationSource}");
+                Logger.LogInfo("Executing weaver");
+                Logger.LogDebug($"Configuration source: {weaver.Config.ConfigurationSource}");
                 try
                 {
                     weaver.Instance.Execute();
@@ -220,8 +220,7 @@ The recommended work around is to avoid using ValueTuple inside a weaver.", exce
                     throw new Exception($"Failed to execute weaver {weaver.Config.AssemblyPath}", exception);
                 }
 
-                var finishedMessage = $"  Finished '{weaver.Config.ElementName}' in {startNew.ElapsedMilliseconds}ms {Environment.NewLine}";
-                Logger.LogDebug(finishedMessage);
+                Logger.LogDebug($"Finished '{weaver.Config.ElementName}' in {startNew.ElapsedMilliseconds}ms");
 
                 ReferenceCleaner.CleanReferences(ModuleDefinition, weaver.Instance, Logger.LogDebug);
             }
@@ -240,7 +239,7 @@ The recommended work around is to avoid using ValueTuple inside a weaver.", exce
             return;
         }
 
-        Logger.LogDebug("  Adding weaving info");
+        Logger.LogDebug("Adding weaving info");
         var startNew = Stopwatch.StartNew();
 
         const TypeAttributes typeAttributes = TypeAttributes.NotPublic | TypeAttributes.Class;
@@ -256,8 +255,7 @@ The recommended work around is to avoid using ValueTuple inside a weaver.", exce
             AddVersionField(configAssembly, name, typeDefinition);
         }
 
-        var finishedMessage = $"  Finished in {startNew.ElapsedMilliseconds}ms {Environment.NewLine}";
-        Logger.LogDebug(finishedMessage);
+        Logger.LogDebug($"Finished in {startNew.ElapsedMilliseconds}ms");
     }
 
     string GetWeavingInfoClassName()
@@ -301,10 +299,9 @@ The recommended work around is to avoid using ValueTuple inside a weaver.", exce
             {
                 Logger.SetCurrentWeaverName(weaver.Config.ElementName);
                 var stopwatch = Stopwatch.StartNew();
-                Logger.LogDebug("  Executing After Weaver");
+                Logger.LogDebug("Executing After Weaver");
                 weaver.Instance.AfterWeaving();
-                var finishedMessage = $"  Finished '{weaver.Config.ElementName}' in {stopwatch.ElapsedMilliseconds}ms {Environment.NewLine}";
-                Logger.LogDebug(finishedMessage);
+                Logger.LogDebug($"Finished '{weaver.Config.ElementName}' in {stopwatch.ElapsedMilliseconds}ms");
             }
             finally
             {

--- a/FodyIsolated/ModuleWriter.cs
+++ b/FodyIsolated/ModuleWriter.cs
@@ -6,7 +6,7 @@ public partial class InnerWeaver
     public virtual void WriteModule()
     {
         var stopwatch = Stopwatch.StartNew();
-        Logger.LogDebug($"  Writing assembly to '{AssemblyFilePath}'.");
+        Logger.LogDebug($"Writing assembly to '{AssemblyFilePath}'.");
 
         var parameters = new WriterParameters
         {
@@ -16,6 +16,6 @@ public partial class InnerWeaver
 
         ModuleDefinition.Assembly.Name.PublicKey = PublicKey;
         ModuleDefinition.Write(AssemblyFilePath, parameters);
-        Logger.LogDebug($"  Finished writing assembly {stopwatch.ElapsedMilliseconds}ms.");
+        Logger.LogDebug($"Finished writing assembly {stopwatch.ElapsedMilliseconds}ms.");
     }
 }

--- a/FodyIsolated/WeaverInitialiser.cs
+++ b/FodyIsolated/WeaverInitialiser.cs
@@ -22,9 +22,9 @@ public partial class InnerWeaver
         weaverInstance.ProjectDirectoryPath = ProjectDirectoryPath;
         weaverInstance.ProjectFilePath = ProjectFilePath;
         weaverInstance.DocumentationFilePath = DocumentationFilePath;
-        weaverInstance.LogDebug = message => Logger.LogDebug("  " + message);
-        weaverInstance.LogInfo = message => Logger.LogInfo("  " + message);
-        weaverInstance.LogMessage = (message, importance) => Logger.LogMessage("  " + message, (int)importance);
+        weaverInstance.LogDebug = message => Logger.LogDebug(message);
+        weaverInstance.LogInfo = message => Logger.LogInfo(message);
+        weaverInstance.LogMessage = (message, importance) => Logger.LogMessage(message, (int)importance);
         weaverInstance.LogWarning = s => Logger.LogWarning(s);
         weaverInstance.LogWarningPoint = LogWarningPoint;
         weaverInstance.LogError = Logger.LogError;


### PR DESCRIPTION
This is just a small cleanup of log messages as I noticed some inconsistencies in their indentation. I hope that's OK for you @SimonCropp.

See also https://github.com/KirillOsenkov/MSBuildStructuredLog/pull/506 - I don't think MSBuild tasks are supposed to log messages ending with a newline.

<details>
<summary>Difference in detailed logging mode</summary>

Before:

```
    Fody: Fody (version 6.5.1.0 @ file:///C:/Users/lucas/Documents/Dev/Fody/packages/fody/6.5.1/netclassictask/Fody.dll) Executing
    Fody: SolutionDirectory path is 'C:\Users\lucas\Documents\Dev\Fody\Integration\'
    Fody: ProjectDirectory: 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb'.
    Fody: ProjectFile: 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\WithEmbeddedPdb.csproj'.
    Fody: AssemblyFile: 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\obj\Release\netstandard2.0\WithEmbeddedPdb.dll'
    Fody: Found path to weavers file 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\FodyWeavers.xml'.
    Fody: Creating a new AssemblyLoadContext
    Fody: Reference count=115
    Fody: References:
  C:\Users\lucas\Documents\Dev\Fody\packages\netstandard.library\2.0.3\build\netstandard2.0\ref\Microsoft.Win32.Primitives.dll
  		C:\Users\lucas\Documents\Dev\Fody\packages\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll
  		C:\Users\lucas\Documents\Dev\Fody\packages\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll
  		(...)
    Fody: Weaver 'C:\Users\lucas\Documents\Dev\Fody\packages\virtuosity.fody\1.21.3\build\..\netclassicweaver\Virtuosity.Fody.dll'.
    Fody:   Initializing weaver
    Fody:   Loading 'C:\Users\lucas\Documents\Dev\Fody\packages\virtuosity.fody\1.21.3\build\..\netclassicweaver\Virtuosity.Fody.dll' from disk.
MSBUILD : warning FodyVersionMismatch: Fody: Weavers should reference at least the current major version of Fody (version 6). The weaver in Virtuosity.Fody references version 3. This may result in incompatibilities at build time such as MissingMethodException being thrown. [C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\WithEmbeddedPdb.csproj]
    Fody: Weaver 'C:\Users\lucas\Documents\Dev\Fody\packages\sampleweaver.fody\6.5.1\build\..\weaver\SampleWeaver.Fody.dll'.
    Fody:   Initializing weaver
    Fody:   Loading 'C:\Users\lucas\Documents\Dev\Fody\packages\sampleweaver.fody\6.5.1\build\..\weaver\SampleWeaver.Fody.dll' from disk.
    Fody: Weavers with 'ShouldCleanReference=true': Virtuosity.Fody
MSBUILD : warning FodyPackageReference: Fody: The package reference for Virtuosity.Fody does not contain PrivateAssets='All' [C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\WithEmbeddedPdb.csproj]
      Fody/Virtuosity:   Executing Weaver 
      Fody/Virtuosity:   Configuration source: C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\FodyWeavers.xml
      Fody/Virtuosity:   	WithEmbeddedPdb.Class1
      Fody/Virtuosity:   Finished 'Virtuosity' in 25ms 
  
      Fody/Virtuosity: 	Removing reference to 'Virtuosity'.
      Fody/SampleWeaver:   Executing Weaver 
      Fody/SampleWeaver:   Configuration source: C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\FodyWeavers.xml
      Fody/SampleWeaver:   Validate Symbols
      Fody/SampleWeaver:   Validating method System.Void WithEmbeddedPdb.Class1::Method()
      Fody/SampleWeaver:   Assembly should have symbols: True
      Fody/SampleWeaver:   Assembly has symbols: True
      Fody/SampleWeaver:   Finished 'SampleWeaver' in 25ms 
  
    Fody:   Adding weaving info
    Fody:   Finished in 1ms 
  
    Fody:   Writing assembly to 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithEmbeddedPdb\obj\Release\netstandard2.0\WithEmbeddedPdb.dll'.
    Fody:   Finished writing assembly 72ms.
      Fody/Virtuosity:   Executing After Weaver
      Fody/Virtuosity:   Finished 'Virtuosity' in 0ms 
  
      Fody/SampleWeaver:   Executing After Weaver
      Fody/SampleWeaver:   Finished 'SampleWeaver' in 0ms 
  
    Fody:   Finished Fody 342ms.
```

After:

```
  Fody: Fody (version 6.5.1.0 @ file:///C:/Users/lucas/Documents/Dev/Fody/packages/fody/6.5.1/netclassictask/Fody.dll) Executing
  Fody: SolutionDirectory path is 'C:\Users\lucas\Documents\Dev\Fody\Integration\'
  Fody: ProjectDirectory: 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb'.
  Fody: ProjectFile: 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\WithNoPdb.csproj'.
  Fody: AssemblyFile: 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\obj\Release\netstandard2.0\WithNoPdb.dll'
  Fody: Found path to weavers file 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\FodyWeavers.xml'.
  Fody: Reference count: 115
  Fody: References:
    C:\Users\lucas\Documents\Dev\Fody\packages\netstandard.library\2.0.3\build\netstandard2.0\ref\Microsoft.Win32.Primitives.dll
    C:\Users\lucas\Documents\Dev\Fody\packages\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll
    C:\Users\lucas\Documents\Dev\Fody\packages\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll
    (...)
  Fody: Module has no debug symbols.
  Fody: Weaver 'C:\Users\lucas\Documents\Dev\Fody\packages\virtuosity.fody\1.21.3\build\..\netclassicweaver\Virtuosity.Fody.dll'.
  Fody:   Initializing weaver
  Fody:   Loading 'C:\Users\lucas\Documents\Dev\Fody\packages\virtuosity.fody\1.21.3\build\..\netclassicweaver\Virtuosity.Fody.dll' from cache.
MSBUILD : warning FodyVersionMismatch: Fody: Weavers should reference at least the current major version of Fody (version 6). The weaver in Virtuosity.Fody references version 3. This may result in incompatibilities at build time such as MissingMethodException being thrown. [C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\WithNoPdb.csproj]
  Fody: Weaver 'C:\Users\lucas\Documents\Dev\Fody\packages\sampleweaver.fody\6.5.1\build\..\weaver\SampleWeaver.Fody.dll'.
  Fody:   Initializing weaver
  Fody:   Loading 'C:\Users\lucas\Documents\Dev\Fody\packages\sampleweaver.fody\6.5.1\build\..\weaver\SampleWeaver.Fody.dll' from cache.
  Fody: Weavers with 'ShouldCleanReference=true': Virtuosity.Fody
MSBUILD : warning FodyPackageReference: Fody: The package reference for Virtuosity.Fody does not contain PrivateAssets='All' [C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\WithNoPdb.csproj]
    Fody/Virtuosity: Executing weaver
    Fody/Virtuosity: Configuration source: C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\FodyWeavers.xml
    Fody/Virtuosity: 	WithNoPdb.Class1
    Fody/Virtuosity: Finished 'Virtuosity' in 0ms
    Fody/Virtuosity: Removing reference to 'Virtuosity'.
    Fody/SampleWeaver: Executing weaver
    Fody/SampleWeaver: Configuration source: C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\FodyWeavers.xml
    Fody/SampleWeaver: Validate Symbols
    Fody/SampleWeaver: Validating method System.Void WithNoPdb.Class1::Method()
    Fody/SampleWeaver: Assembly should have symbols: False
    Fody/SampleWeaver: Assembly has symbols: False
    Fody/SampleWeaver: Finished 'SampleWeaver' in 0ms
  Fody: Adding weaving info
  Fody: Finished in 0ms
  Fody: Writing assembly to 'C:\Users\lucas\Documents\Dev\Fody\Integration\WithNoPdb\obj\Release\netstandard2.0\WithNoPdb.dll'.
  Fody: Finished writing assembly 0ms.
    Fody/Virtuosity: Executing After Weaver
    Fody/Virtuosity: Finished 'Virtuosity' in 0ms
    Fody/SampleWeaver: Executing After Weaver
    Fody/SampleWeaver: Finished 'SampleWeaver' in 0ms
  Fody: Finished Fody 21ms.
```
</details>


<details>
<summary>Difference in the binary log viewer</summary>

Before:

![image](https://user-images.githubusercontent.com/7913492/121805862-612fc200-cc4d-11eb-8af7-a268268a1aa2.png)

After:

![image](https://user-images.githubusercontent.com/7913492/121805875-6db41a80-cc4d-11eb-976f-5615cfbd5a6e.png)

</details>

