### PR TITLE
BuildingForLiveUnitTesting property inclusion supersedes DesignTimeBuild exclusion on FodyTarget

### DIFF
--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -29,7 +29,7 @@
   <Target
       Name="FodyTarget"
       AfterTargets="AfterCompile"
-      Condition="Exists(@(IntermediateAssembly)) And $(DesignTimeBuild) != true And $(DisableFody) != true"
+      Condition="Exists(@(IntermediateAssembly)) And ($(DesignTimeBuild) != true Or $(BuildingForLiveUnitTesting) == true) And $(DisableFody) != true"
       DependsOnTargets="$(FodyDependsOnTargets)"
       Inputs="@(IntermediateAssembly);$(ProjectWeaverXml)"
       Outputs="$(IntermediateOutputPath)$(MSBuildProjectFile).Fody.CopyLocal.cache">


### PR DESCRIPTION
FodyTarget was excluded from execution during LiveUnitTesting due to the `DesignTimeBuild` condition. Adding inclusion through `BuildingForLiveUnitTesting` allows Fody to work in LUT scenarios but still be excluded in other design-time build scenarios.