### PR TITLE
Take `$(TreatWarningsAsErrors)` into account

### DIFF
--- a/Fody/BuildLogger.cs
+++ b/Fody/BuildLogger.cs
@@ -7,6 +7,8 @@ public class BuildLogger :
     ILogger
 {
     public IBuildEngine BuildEngine { get; set; } = null!;
+    public bool TreatWarningsAsErrors { get; set; }
+
     string? currentWeaverName;
 
     public virtual void SetCurrentWeaverName(string weaverName) =>
@@ -27,8 +29,16 @@ public class BuildLogger :
     public virtual void LogWarning(string message, string? code) =>
         LogWarning(message, null, 0, 0, 0, 0, code);
 
-    public virtual void LogWarning(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string? code) =>
+    public virtual void LogWarning(string message, string? file, int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, string? code)
+    {
+        if (TreatWarningsAsErrors)
+        {
+            LogError(message, file, lineNumber, columnNumber, endLineNumber, endColumnNumber);
+            return;
+        }
+
         BuildEngine.LogWarningEvent(new("", code ?? "", file, lineNumber, columnNumber, endLineNumber, endColumnNumber, PrependMessage(message), "", "Fody"));
+    }
 
     public virtual void LogError(string message) =>
         LogError(message, null, 0, 0, 0, 0);

--- a/Fody/Fody.targets
+++ b/Fody/Fody.targets
@@ -12,6 +12,7 @@
     <FodyAfterTargets Condition="($(MsBuildMajorVersion) &lt; 17) AND '$(FodyAfterTargets)'==''">AfterCompile</FodyAfterTargets>
     <TargetsTriggeredByCompilation Condition="'$(FodyAfterTargets)'==''">$(TargetsTriggeredByCompilation);FodyTarget</TargetsTriggeredByCompilation>
     <DisableFody Condition='$(UseWPF)==true AND $(MSBuildProjectName.EndsWith("_wpftmp"))'>true</DisableFody>
+    <FodyTreatWarningsAsErrors Condition="$(FodyTreatWarningsAsErrors) == ''">$(TreatWarningsAsErrors)</FodyTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup Condition="Exists($(ProjectWeaverXml))">
@@ -62,6 +63,7 @@
         IntermediateCopyLocalFilesCache="$(IntermediateOutputPath)$(MSBuildProjectFile).Fody.CopyLocal.cache"
         RuntimeCopyLocalFilesCache="$(IntermediateOutputPath)$(MSBuildProjectFile).Fody.RuntimeCopyLocal.cache"
         GenerateXsd="$(FodyGenerateXsd)"
+        TreatWarningsAsErrors="$(FodyTreatWarningsAsErrors)"
       >
 
       <Output

--- a/Fody/WeavingTask.cs
+++ b/Fody/WeavingTask.cs
@@ -57,6 +57,7 @@ public class WeavingTask :
     public string RuntimeCopyLocalFilesCache { get; set; } = null!;
 
     public bool GenerateXsd { get; set; }
+    public bool TreatWarningsAsErrors { get; set; }
 
     public override bool Execute()
     {
@@ -70,6 +71,7 @@ public class WeavingTask :
         var buildLogger = new BuildLogger
         {
             BuildEngine = BuildEngine,
+            TreatWarningsAsErrors = TreatWarningsAsErrors
         };
 
         processor = new()

--- a/Tests/Fody/BuildLoggerTests.cs
+++ b/Tests/Fody/BuildLoggerTests.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+using Xunit;
+
+public class BuildLoggerTests
+{
+    MockBuildEngine buildEngine = new();
+    BuildLogger buildLogger;
+
+    public BuildLoggerTests() =>
+        buildLogger = new()
+        {
+            BuildEngine = buildEngine
+        };
+
+    [Fact]
+    public void TreatWarningsAsErrors()
+    {
+        buildLogger.TreatWarningsAsErrors = true;
+        buildLogger.LogWarning("Message", "Code");
+
+        Assert.Single(buildEngine.Errors);
+        Assert.Empty(buildEngine.Warnings);
+    }
+
+    [Fact]
+    public void DontTreatWarningsAsErrors()
+    {
+        buildLogger.TreatWarningsAsErrors = false;
+        buildLogger.LogWarning("Message", "Code");
+
+        Assert.Single(buildEngine.Warnings);
+        Assert.Empty(buildEngine.Errors);
+    }
+
+    private class MockBuildEngine : IBuildEngine
+    {
+        public List<BuildWarningEventArgs> Warnings = new();
+        public List<BuildErrorEventArgs> Errors = new();
+
+        public void LogErrorEvent(BuildErrorEventArgs e) =>
+            Errors.Add(e);
+
+        public void LogWarningEvent(BuildWarningEventArgs e) =>
+            Warnings.Add(e);
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+        }
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+        }
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) =>
+            false;
+
+        public bool ContinueOnError => false;
+        public int LineNumberOfTaskNode => 0;
+        public int ColumnNumberOfTaskNode => 0;
+        public string ProjectFileOfTaskNode => "";
+    }
+}


### PR DESCRIPTION
I figured maybe Fody should take `$(TreatWarningsAsErrors)` into account, and emit errors instead of warnings when this property is set to true.

This PR adds a `FodyTreatWarningsAsErrors` property which is set to `$(TreatWarningsAsErrors)` by default, but can be overridden if needed.

This is a suggestion, tell me what you think. **This could be a breaking change to existing users.**

Note that the same outcome can be achieved without this PR by setting `$(MSBuildTreatWarningsAsErrors)` to true - in that case *any* warning emitted during the build will become an error, not just Fody warnings.

*(sorry for all the edits, I must have pressed a shortcut and the PR got submitted before I finished writing the summary)*