### PR TITLE
Base load contexts on weaver paths

### DIFF
--- a/Fody/AssemblyPathSet.cs
+++ b/Fody/AssemblyPathSet.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+
+namespace Fody;
+
+public sealed class AssemblyPathSet : IEquatable<AssemblyPathSet>
+{
+    readonly HashSet<string> assemblyPaths;
+    readonly int hashCode;
+
+    public IReadOnlyCollection<string> AssemblyPaths => assemblyPaths;
+
+    public AssemblyPathSet(IEnumerable<string> paths)
+    {
+        var stringComparer = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        assemblyPaths = new(paths, stringComparer);
+        hashCode = 0;
+
+        foreach (var path in assemblyPaths.OrderBy(i => i, stringComparer))
+        {
+            hashCode = (hashCode * 397) ^ path.GetHashCode();
+        }
+    }
+
+    public bool Equals(AssemblyPathSet? other) =>
+        other is not null && assemblyPaths.SetEquals(other.assemblyPaths);
+
+    public override bool Equals(object? obj) =>
+        obj is AssemblyPathSet other && Equals(other);
+
+    public override int GetHashCode() =>
+        hashCode;
+}

--- a/FodyIsolated/AssemblyLoader.cs
+++ b/FodyIsolated/AssemblyLoader.cs
@@ -14,14 +14,20 @@ public partial class InnerWeaver
         return assemblies[assemblyPath] = LoadFromFile(assemblyPath);
     }
 
-    // ReSharper disable once MemberCanBeMadeStatic.Local
     Assembly LoadFromFile(string assemblyPath)
     {
-        #if(NETSTANDARD)
-        return LoadContext.LoadNotLocked(assemblyPath);
-        #else
-        var rawAssembly = File.ReadAllBytes(assemblyPath);
-        return Assembly.Load(rawAssembly);
-        #endif
+        try
+        {
+#if NETSTANDARD
+            return LoadContext.LoadNotLocked(assemblyPath);
+#else
+            var rawAssembly = File.ReadAllBytes(assemblyPath);
+            return Assembly.Load(rawAssembly);
+#endif
+        }
+        catch (Exception ex)
+        {
+            throw new WeavingException($"Could not load weaver assembly from {assemblyPath}: {ex.Message}");
+        }
     }
 }

--- a/Tests/Fody/AssemblyPathSetTests.cs
+++ b/Tests/Fody/AssemblyPathSetTests.cs
@@ -1,0 +1,23 @@
+namespace Tests.Fody;
+
+public class AssemblyPathSetTests
+{
+    [Fact]
+    public void ShouldDetectEquality()
+    {
+        var a = new AssemblyPathSet(["foo", "bar"]);
+        var b = new AssemblyPathSet(["bar", "foo", "bar"]);
+
+        Assert.Equal(a, b);
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [Fact]
+    public void ShouldDetectInequality()
+    {
+        var a = new AssemblyPathSet(["foo", "bar"]);
+        var b = new AssemblyPathSet(["foo", "baz"]);
+
+        Assert.NotEqual(a, b);
+    }
+}


### PR DESCRIPTION

Currently, Fody creates an assembly load context per solution directory. A problem with that approach is that if two projects in the same solution try to load two different versions of the same weaver on a single build node, the second load will fail.

This PR changes this logic to create assembly load contexts based on the *set of weaver assembly paths* which will be used in a given project. Therefore, two projects which use two different versions of the same weaver will get two different load contexts since the weaver path won't be the same (and even if it were the same path, the `WeaversHistory` class already takes care of this case).

Note that I may be missing some context here (I don't know why the load contexts were cached by solution path or why they were cached in the first place).

Closes #1268

