### PR TITLE
Avoid constructing `StrongNameKeyPair`.

### DIFF
--- a/FodyIsolated/ModuleWriter.cs
+++ b/FodyIsolated/ModuleWriter.cs
@@ -9,7 +9,7 @@ public partial class InnerWeaver
 
         var parameters = new WriterParameters
         {
-            StrongNameKeyPair = StrongNameKeyPair,
+            StrongNameKeyBlob = StrongNameKeyBlob,
             WriteSymbols = hasSymbols
         };
 


### PR DESCRIPTION
#### You should already be a Patron

(I tried becoming one but my card was declined)

#### Description

This PR uses an alternative way to pass to Cecil the strong-name key pair, without needing to create legacy `StrongNameKeyPair` objects. This will reduce Fody's reliance on its fork of Mono.Cecil, and unless there are other reasons to use it, I can replace it with the upstream NuGet package in this or a subsequent PR.

#### The solution

Instead of setting a `StrongNameKeyPair` to `WriterParameters.StrongNameKeyPair`, we pass the key file's content directly to the `StrongNameKeyBlob` property. Cecil will read it in a cross-platform way.

Fody has been using the `StrongNameKeyPair.PublicKey` property to set the assembly name's public key, and determine if the file actually points to a private key. This PR stops changing the assembly name because I discovered that [Cecil already does that](https://github.com/jbevain/cecil/blob/5de7d8cbc91f6fd98dcc24b26b8c398db497809c/Mono.Cecil/AssemblyWriter.cs#L106), and manually examines the key blob to determine if it is a private key.

#### Todos

 * [ ] Related issues
 * [ ] Tests
 * [ ] Documentation