### PR TITLE
Clean-up unnecessary dependencies.

### DIFF
--- a/FodyHelpers.Tests/FodyHelpers.Tests.csproj
+++ b/FodyHelpers.Tests/FodyHelpers.Tests.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.7" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Verify.Xunit" Version="30.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" PrivateAssets="All" />

--- a/FodyTasks/FodyTasks.csproj
+++ b/FodyTasks/FodyTasks.csproj
@@ -11,7 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.4" PrivateAssets="All" IsPinned="true" Justification="Must stick with version 17.11.4 to stay backward compatible - we don't ship this, but depend on the version installed with dotnet/msbuild"/>
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FodyTasks/FodyTasks.csproj
+++ b/FodyTasks/FodyTasks.csproj
@@ -11,8 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.11.4" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="All" IsPinned="true" Justification="Must stick with version 17.11.4 to stay backward compatible - we don't ship this, but depend on the version installed with dotnet/msbuild"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48;net9.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.7" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Verify.Xunit" Version="30.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" PrivateAssets="All" />


### PR DESCRIPTION
#### You should already be a Patron

I am.

#### Guidance

If you are uncertain if the PR will be accepted, outline the proposal in an issue to confirm it is viable.

Even if the feature is a good idea and viable, it may not be accepted since the ongoing effort in maintaining the feature may outweigh the benefit it delivers.

#### Description

Building `Fody.sln` with the .NET 10 SDK causes the following warnings-turned-errors:

```
8>error NU1903: Warning As Error: Package 'Microsoft.Build.Tasks.Core' 17.11.4 has a known high severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc
11>C:\Users\teo\code\Fody\FodyHelpers.Tests\FodyHelpers.Tests.csproj : error NU1510: Warning As Error: PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
12>C:\Users\teo\code\Fody\Tests\Tests.csproj : error NU1510: Warning As Error: PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
```

#### The solution

* The dependency to `Microsoft.CSharp` is not needed and was removed.
* Instead of `Microsoft.Build.Tasks.Core`, we depend on `Microsoft.Build.Utilities.Core`, which is what we actually need and is not vulnerable.

#### Todos

 * [ ] Related issues
 * [ ] Tests
 * [ ] Documentation