### PR TITLE
Target .NET 8 instead of .NET Standard 2.0 and support unloading the `IsolatedAssemblyLoadContext`.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,7 @@
     <PackageReadmeFile>package_readme.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <Nullable>enable</Nullable>
-    <!-- work around https://github.com/dotnet/msbuild/issues/4303 -->
-    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
+    <Nullable Condition="'$(TargetFramework)' != 'net8.0'">annotations</Nullable>
     <ResolveAssemblyReferencesSilent>true</ResolveAssemblyReferencesSilent>
     <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>

--- a/Fody/build/Fody.targets
+++ b/Fody/build/Fody.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectWeaverXml Condition="$(ProjectWeaverXml) == ''">$(ProjectDir)FodyWeavers.xml</ProjectWeaverXml>
     <FodyPath Condition="$(FodyPath) == ''">$(MSBuildThisFileDirectory)..\</FodyPath>
-    <FodyAssemblyDirectory Condition="$(MSBuildRuntimeType) == 'Core'">$(FodyPath)tasks\netstandard2.0</FodyAssemblyDirectory>
+    <FodyAssemblyDirectory Condition="$(MSBuildRuntimeType) == 'Core'">$(FodyPath)tasks\net8.0</FodyAssemblyDirectory>
     <FodyAssemblyDirectory Condition="$(MSBuildRuntimeType) != 'Core'">$(FodyPath)tasks\net472</FodyAssemblyDirectory>
     <FodyAssembly Condition="$(FodyAssembly) == ''">$(FodyAssemblyDirectory)\FodyTasks.dll</FodyAssembly>
     <DefaultItemExcludes>$(DefaultItemExcludes);FodyWeavers.xsd</DefaultItemExcludes>

--- a/FodyCommon/AssemblyLocation.cs
+++ b/FodyCommon/AssemblyLocation.cs
@@ -12,7 +12,7 @@ public static class AssemblyLocation
             .Replace(@"file:\\\", "")
             .Replace(@"file:\\", "");
 
-        CurrentDirectory = Path.GetDirectoryName(path);
+        CurrentDirectory = Path.GetDirectoryName(path) ?? "";
     }
 
     public static readonly string CurrentDirectory;

--- a/FodyCommon/ExceptionExtensions.cs
+++ b/FodyCommon/ExceptionExtensions.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 public static class ExceptionExtensions
 {
-    public static string ToFriendlyString(this Exception exception)
+    public static string ToFriendlyString([MaybeNull] this Exception exception)
     {
         var stringBuilder = new StringBuilder();
         stringBuilder.Append("An unhandled exception occurred:");

--- a/FodyCommon/FodyCommon.csproj
+++ b/FodyCommon/FodyCommon.csproj
@@ -1,13 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-
-  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />

--- a/FodyCommon/IInnerWeaver.cs
+++ b/FodyCommon/IInnerWeaver.cs
@@ -18,7 +18,7 @@ public interface IInnerWeaver : IDisposable
     string ProjectDirectoryPath { get; set; }
     string ProjectFilePath { get; set; }
     string? DocumentationFilePath { get; set; }
-    #if(NETSTANDARD)
+    #if NET
     IsolatedAssemblyLoadContext LoadContext { get; set; }
     #endif
     void Execute();

--- a/FodyCommon/IsolatedAssemblyLoadContext.cs
+++ b/FodyCommon/IsolatedAssemblyLoadContext.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 #if NET472
 using System;
 
@@ -19,9 +19,6 @@ public class IsolatedAssemblyLoadContext
     {
         var assemblyFile = Path.Combine(AssemblyLocation.CurrentDirectory, "FodyIsolated.dll");
         var innerWeaver = (IInnerWeaver)appDomain.CreateInstanceFromAndUnwrap(assemblyFile, "InnerWeaver");
-        #if(NETSTANDARD)
-        innerWeaver.LoadContext = this;
-        #endif
         return innerWeaver;
     }
 
@@ -35,6 +32,8 @@ using System.Runtime.Loader;
 public class IsolatedAssemblyLoadContext :
     AssemblyLoadContext
 {
+    public IsolatedAssemblyLoadContext() : base("Fody.IsolatedAssemblyLoadContext", isCollectible: true) { }
+
     protected override Assembly? Load(AssemblyName assemblyName)
     {
         if (assemblyName.Name == "FodyCommon")
@@ -55,7 +54,7 @@ public class IsolatedAssemblyLoadContext :
     {
         var assemblyFile = Path.Combine(AssemblyLocation.CurrentDirectory, "FodyIsolated.dll");
         var assembly = LoadFromAssemblyPath(assemblyFile);
-        var innerWeaver = (IInnerWeaver)assembly.CreateInstance("InnerWeaver");
+        var innerWeaver = (IInnerWeaver)assembly.CreateInstance("InnerWeaver")!;
         innerWeaver.LoadContext = this;
         return innerWeaver;
     }
@@ -64,11 +63,6 @@ public class IsolatedAssemblyLoadContext :
     {
         using var stream = File.OpenRead(assemblyPath);
         return LoadFromStream(stream);
-    }
-
-    public void Unload()
-    {
-        //TODO: Not supported on .NET Core yet
     }
 }
 #endif

--- a/FodyHelpers/BaseModuleWeaver.cs
+++ b/FodyHelpers/BaseModuleWeaver.cs
@@ -1,11 +1,11 @@
-﻿namespace Fody;
+namespace Fody;
 
 /// <summary>
 /// Base class for module weavers.
 /// </summary>
 public abstract class BaseModuleWeaver
 {
-    static XElement Empty = new("Empty");
+    static XElement Empty { get; } = new("Empty");
 
     /// <summary>
     /// The full element XML from FodyWeavers.xml.

--- a/FodyHelpers/Testing/PeVerifier.cs
+++ b/FodyHelpers/Testing/PeVerifier.cs
@@ -1,4 +1,4 @@
-﻿namespace Fody;
+namespace Fody;
 
 /// <summary>
 /// Verifies assemblies using peverify.exe.
@@ -110,7 +110,7 @@ public static class PeVerifier
         ignoreCodes.Add("0x80070002");
         ignoreCodes.Add("0x80131252");
         workingDirectory ??= Path.GetDirectoryName(assemblyPath);
-        var processStartInfo = new ProcessStartInfo(peverifyPath)
+        var processStartInfo = new ProcessStartInfo(peverifyPath!)
         {
             Arguments = $"\"{assemblyPath}\" /hresult /nologo /ignore={string.Join(",", ignoreCodes)}",
             WorkingDirectory = workingDirectory,
@@ -119,7 +119,7 @@ public static class PeVerifier
             RedirectStandardOutput = true
         };
 
-        using var process = Process.Start(processStartInfo);
+        using var process = Process.Start(processStartInfo)!;
         output = process.StandardOutput.ReadToEnd();
         output = Regex.Replace(output, "^All Classes and Methods.*", "");
         output = output.Trim();

--- a/FodyIsolated/AssemblyLoader.cs
+++ b/FodyIsolated/AssemblyLoader.cs
@@ -18,7 +18,7 @@ public partial class InnerWeaver
     {
         try
         {
-#if NETSTANDARD
+#if NET
             return LoadContext.LoadNotLocked(assemblyPath);
 #else
             var rawAssembly = File.ReadAllBytes(assemblyPath);

--- a/FodyIsolated/ExceptionExtensions.cs
+++ b/FodyIsolated/ExceptionExtensions.cs
@@ -8,6 +8,10 @@ public static class ExceptionExtensions
 
         foreach (var loaderException in exception.LoaderExceptions)
         {
+            if (loaderException == null)
+            {
+                continue;
+            }
             builder.AppendLine(loaderException.ToString());
         }
 

--- a/FodyIsolated/FodyIsolated.csproj
+++ b/FodyIsolated/FodyIsolated.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/FodyIsolated/FodyVersion.cs
+++ b/FodyIsolated/FodyVersion.cs
@@ -1,12 +1,17 @@
 public static class FodyVersion
 {
-    public static readonly Version Version = typeof(FodyVersion).Assembly.GetName().Version;
+    public static readonly Version Version = typeof(FodyVersion).Assembly.GetName().Version ?? new Version();
     public static readonly int Major = Version.Major;
 
     public static bool WeaverRequiresUpdate(Assembly assembly, out int referencedVersion)
     {
-        var reference = FindFodyHelpersReference(assembly);
-        referencedVersion = reference.Version.Major;
+        var version = FindFodyHelpersReference(assembly).Version;
+        if (version == null)
+        {
+            referencedVersion = 0;
+            return true;
+        }
+        referencedVersion = version.Major;
         return referencedVersion < Major;
     }
 

--- a/FodyIsolated/WeaverInitialiser.cs
+++ b/FodyIsolated/WeaverInitialiser.cs
@@ -10,7 +10,7 @@ public partial class InnerWeaver
 
         weaverInstance.ModuleDefinition = ModuleDefinition;
         weaverInstance.AssemblyFilePath = AssemblyFilePath;
-        weaverInstance.AddinDirectoryPath = Path.GetDirectoryName(weaverEntry.AssemblyPath);
+        weaverInstance.AddinDirectoryPath = Path.GetDirectoryName(weaverEntry.AssemblyPath) ?? "";
         weaverInstance.References = References;
         weaverInstance.ReferenceCopyLocalPaths = ReferenceCopyLocalPaths;
         weaverInstance.SolutionDirectoryPath = SolutionDirectoryPath;

--- a/FodyTasks/ConfigFileFinder/ConfigFileFinder.cs
+++ b/FodyTasks/ConfigFileFinder/ConfigFileFinder.cs
@@ -36,7 +36,7 @@ public static class ConfigFileFinder
 
         foreach (var configFile in configFiles)
         {
-            foreach (var element in configFile.Document.Root.Elements())
+            foreach (var element in configFile.Document.Root?.Elements() ?? [])
             {
                 var elementName = element.Name.LocalName;
 
@@ -174,14 +174,14 @@ public static class ConfigFileFinder
                 return;
             }
 
-            var hasNamespace = doc.Root.Attributes()
-                .Any(attr => !attr.IsNamespaceDeclaration &&
+            var hasNamespace = doc.Root?.Attributes()
+                ?.Any(attr => !attr.IsNamespaceDeclaration &&
                              attr.Name.LocalName == "noNamespaceSchemaLocation" &&
-                             string.Equals(attr.Value, "FodyWeavers.xsd", StringComparison.OrdinalIgnoreCase));
+                             string.Equals(attr.Value, "FodyWeavers.xsd", StringComparison.OrdinalIgnoreCase)) ?? false;
 
             if (!hasNamespace)
             {
-                doc.Root.Add(SchemaInstanceAttributes);
+                doc.Root!.Add(SchemaInstanceAttributes);
                 doc.Save(projectConfigFilePath);
             }
 
@@ -195,7 +195,7 @@ public static class ConfigFileFinder
 
     static bool ShouldGenerateXsd(XDocument doc, bool defaultGenerateXsd)
     {
-        if (doc.Root.TryReadBool("GenerateXsd", out var generateXsd))
+        if (doc.Root?.TryReadBool("GenerateXsd", out var generateXsd) ?? false)
         {
             return generateXsd;
         }

--- a/FodyTasks/FodyTasks.csproj
+++ b/FodyTasks/FodyTasks.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/FodyTasks/Processor.cs
+++ b/FodyTasks/Processor.cs
@@ -34,7 +34,7 @@ public partial class Processor
     {
         var assembly = typeof(Processor).Assembly;
 
-        Logger.LogInfo($"Fody (version {assembly.GetName().Version} @ {assembly.CodeBase}) Executing");
+        Logger.LogInfo($"Fody (version {assembly.GetName().Version} @ {assembly.Location}) Executing");
 
         var stopwatch = Stopwatch.StartNew();
 

--- a/FodyTasks/SolutionDirectoryFinder.cs
+++ b/FodyTasks/SolutionDirectoryFinder.cs
@@ -12,6 +12,6 @@ public class SolutionDirectoryFinder
             return solutionDir!;
         }
 
-        return Directory.GetParent(projectDirectory).FullName;
+        return Directory.GetParent(projectDirectory)?.FullName ?? "";
     }
 }

--- a/FodyTasks/Verify/Verifier.cs
+++ b/FodyTasks/Verify/Verifier.cs
@@ -1,4 +1,4 @@
-﻿public class Verifier
+public class Verifier
 {
     public ILogger Logger = null!;
     public string SolutionDirectory = null!;
@@ -82,7 +82,7 @@
         {
             var configXml = configFile.Document;
             var element = configXml.Root;
-            if (element.TryReadBool("VerifyAssembly", out var value))
+            if (element?.TryReadBool("VerifyAssembly", out var value) ?? false)
             {
                 return value;
             }
@@ -96,7 +96,7 @@
         {
             var configXml = configFile.Document;
             var element = configXml.Root;
-            var codesConfigs = (string)element.Attribute("VerifyIgnoreCodes");
+            var codesConfigs = (string?)element?.Attribute("VerifyIgnoreCodes");
             if (string.IsNullOrWhiteSpace(codesConfigs))
             {
                 continue;

--- a/FodyTasks/WeavingTask.cs
+++ b/FodyTasks/WeavingTask.cs
@@ -160,7 +160,7 @@ public class WeavingTask :
             .Split(';')
             .Select(name => name.Trim())
             .Where(name => !string.IsNullOrEmpty(name))
-            .DefaultIfEmpty();
+            .DefaultIfEmpty()!;
 
     ITaskItem? GetPackageReference(ITaskItem weaverFileItem)
     {


### PR DESCRIPTION
#### You should already be a Patron

I am.

#### Description

This PR retargets the libraries from .NET Standard 2.0 to .NET 8, allowing us to unload the assemblies inside an `IsolatedAssemblyLoadContext`. This update caused several nullability warnings that were fixed in the same PR.

I picked .NET 8 because as of now it is the earliest supported .NET version. [The docs](https://github.com/Fody/Home/blob/master/pages/supported-runtimes-and-ide.md#visual-studio-support) state that Fody is supported on .NET Core SDK 2.2.105 or higher; we will need to update it (preferably to something like "any currently supported .NET SDK version"). If we want to support earlier .NET SDKs, let me know, we can target .NET 6 or even .NET Core 3.1.