### PR TITLE
Bump Mircosoft.Build.* packges by security reasons

### DIFF
--- a/FodyHelpers.Tests/FodyHelpers.Tests.csproj
+++ b/FodyHelpers.Tests/FodyHelpers.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\cecil\symbols\pdb\Mono.Cecil.Pdb.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Verify.Xunit" Version="30.7.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="All" />

--- a/FodyTasks/FodyTasks.csproj
+++ b/FodyTasks/FodyTasks.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" PrivateAssets="All" IsPinned="true" Justification="Must stick with version 17.11.4 to stay backward compatible - we don't ship this, but depend on the version installed with dotnet/msbuild"/>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" PrivateAssets="All" IsPinned="true" Justification="Must stick with version 17.11.4 to stay backward compatible - we don't ship this, but depend on the version installed with dotnet/msbuild" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Verify.Xunit" Version="30.7.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="All" />


### PR DESCRIPTION
Bump Mircosoft.Build.* to 18.0.2 packages according to vulnerability notes (CVE-2025-26646):
https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-26646
Also Mircosoft.Net.Test.Sdk updated to 18.0.1.