### PR TITLE
Fix case-sensitivity and parsing edge cases in config handling

### DIFF
--- a/FodyHelpers.Tests/ConfigReaderTests.cs
+++ b/FodyHelpers.Tests/ConfigReaderTests.cs
@@ -17,6 +17,12 @@ public class ConfigReaderTests
         Assert.True(xElementTrue.ReadBool("Name", false));
         var xElement1 = XElement.Parse("<Node Name='1'/>");
         Assert.True(xElement1.ReadBool("Name", false));
+        var xElementTrueMixedCase = XElement.Parse("<Node Name='True'/>");
+        Assert.True(xElementTrueMixedCase.ReadBool("Name", false));
+        var xElementFalseMixedCase = XElement.Parse("<Node Name='False'/>");
+        Assert.False(xElementFalseMixedCase.ReadBool("Name", true));
+        var xElementTrueUpperCase = XElement.Parse("<Node Name='TRUE'/>");
+        Assert.True(xElementTrueUpperCase.ReadBool("Name", false));
         var xElementNone = XElement.Parse("<Node />");
         Assert.False(xElementNone.ReadBool("Name", false));
         var xElementDefault = XElement.Parse("<Node/>");

--- a/FodyHelpers/ConfigReader.cs
+++ b/FodyHelpers/ConfigReader.cs
@@ -33,7 +33,7 @@ static class ConfigReader
 
         try
         {
-            return XmlConvert.ToBoolean(value);
+            return XmlConvert.ToBoolean(value.ToLowerInvariant());
         }
         catch
         {

--- a/FodyTasks/ConfigFileFinder/ConfigFileFinder.cs
+++ b/FodyTasks/ConfigFileFinder/ConfigFileFinder.cs
@@ -74,7 +74,6 @@ public static class ConfigFileFinder
             .ToArray();
 
         root.Add(elements);
-        weaverConfig.Save(projectConfigFilePath);
 
         var writerSettings = new XmlWriterSettings
         {

--- a/FodyTasks/ExtractConstants.cs
+++ b/FodyTasks/ExtractConstants.cs
@@ -6,6 +6,6 @@ static class ExtractConstants
         {
             return new();
         }
-        return input.Split(';').ToList();
+        return input.Split([';'], StringSplitOptions.RemoveEmptyEntries).ToList();
     }
 }

--- a/FodyTasks/Processor.cs
+++ b/FodyTasks/Processor.cs
@@ -72,7 +72,7 @@ public partial class Processor
         ConfigEntries = ConfigFileFinder.ParseWeaverConfigEntries(ConfigFiles);
 
         var extraEntries = ConfigEntries.Values
-            .Where(entry => !entry.ConfigFile.AllowExtraEntries && !Weavers.Any(weaver => string.Equals(weaver.ElementName, entry.ElementName)))
+            .Where(entry => !entry.ConfigFile.AllowExtraEntries && !Weavers.Any(weaver => string.Equals(weaver.ElementName, entry.ElementName, StringComparison.OrdinalIgnoreCase)))
             .ToArray();
 
         const string missingWeaversHelp = "Add the desired weavers via their nuget package.";


### PR DESCRIPTION
- Match weaver element names case-insensitively in extra-entry validation, so a case-mismatched FodyWeavers.xml element no longer fails the build with a misleading "No weavers found"
- ConfigReader.ReadBool now accepts mixed-case true/false, consistent with TryReadBool
- Drop empty entries when splitting DefineConstants
- Remove redundant initial save in ConfigFileFinder.GenerateDefault
